### PR TITLE
fix comment widget loading users with Account._listUsers

### DIFF
--- a/AppBuilder/platform/views/ABViewComment.js
+++ b/AppBuilder/platform/views/ABViewComment.js
@@ -458,7 +458,7 @@ module.exports = class ABViewComment extends ABViewCommentCore {
    }
 
    getUsers() {
-      return this.AB.Account.usersAll().map((u) => {
+      return this.AB.Account.userList().map((u) => {
          return {
             id: u.username,
             value: u.username,


### PR DESCRIPTION
Was using `Account.usersAll()`  should be `Account.userList`