### PR TITLE
When grid was refactored we left out the height settings.

### DIFF
--- a/AppBuilder/platform/views/ABViewGrid.js
+++ b/AppBuilder/platform/views/ABViewGrid.js
@@ -203,6 +203,7 @@ class ABViewGridComponent extends ABViewComponent {
          prerender: false,
          editable: settings.isEditable,
          fixedRowHeight: false,
+         height: settings.height || 0,
          editaction: "custom",
          select: selectType,
          footer:


### PR DESCRIPTION
NOTE: When height is 0 webix interprets that as auto height