### PR TITLE
Load and cache definitions as js

### DIFF
--- a/config/Config.js
+++ b/config/Config.js
@@ -97,7 +97,7 @@ class Config {
     *          { ABDefinition.id : {ABDefinition} }  hash of definitions.
     */
    definitions() {
-      return this._config.definitions;
+      return window.definitions;
    }
 
    error(/* ...args */) {

--- a/init/Bootstrap.js
+++ b/init/Bootstrap.js
@@ -28,6 +28,7 @@ import FormIOBuilderCSS from "../node_modules/formiojs/dist/formio.builder.min.c
 
 import initConfig from "../init/initConfig.js";
 import initDiv from "../init/initDiv.js";
+import initDefinitions from "../init/initDefinitions.js";
 // import initResources from "../init/initResources.js";
 
 // import JSZipUtils from "jszip-utils/dist/jszip-utils.min.js";
@@ -91,6 +92,13 @@ class Bootstrap extends EventEmitter {
                // 2) Request the User's Configuration Information from the
                //    server.
                return initConfig.init(this);
+               //load the definitions for current user
+            })
+            // load definitions for current user
+            .then(async () => {
+               if (Config.userConfig()) {
+                  await initDefinitions.init(this);
+               }
             })
 
             .then(() => {

--- a/init/initDefinitions.js
+++ b/init/initDefinitions.js
@@ -1,0 +1,37 @@
+export default {
+   init: async (BS) => {
+      // BS {Bootstrap}
+      // The initial Bootstrap object found in "./Bootstrap.js"
+      const headers = new Headers();
+      const token = BS.Config.setting("tenant");
+      if (token) {
+         headers.append("tenant-token", token);
+      }
+
+      const response = await fetch("/definition/check-update", { headers });
+      if (!response.ok) {
+         BS.error(`Error communicating with Server: ${response.status}`);
+      }
+      const res = await response.json();
+      const updated = res.data;
+
+      const loadDefinitions = await new Promise((resolve, reject) => {
+         var cb = () => resolve();
+         // Adding the script tag to the head as suggested before
+         const head = document.head;
+         const script = document.createElement("script");
+         script.type = "text/javascript";
+         script.src = `/definition/myapps?v=${updated}`;
+
+         // Then bind the event to the callback function.
+         // There are several events for cross browser compatibility.
+         script.onreadystatechange = cb;
+         script.onload = cb;
+         script.onerror = () => {
+            reject(new Error(`Error defs`));
+         };
+         // Fire the loading
+         head.appendChild(script);
+      });
+   },
+};

--- a/init/initDefinitions.js
+++ b/init/initDefinitions.js
@@ -15,7 +15,7 @@ export default {
       const res = await response.json();
       const updated = res.data;
 
-      const loadDefinitions = await new Promise((resolve, reject) => {
+      await new Promise((resolve, reject) => {
          var cb = () => resolve();
          // Adding the script tag to the head as suggested before
          const head = document.head;


### PR DESCRIPTION
- Requests definition separate from config.
- Request the time server side definitions cache was changed
- Adds this time to the definitions request so that new definitions will be requested if the time is different form the browser cached request