### PR TITLE
fix idbase in grid export popup

### DIFF
--- a/AppBuilder/platform/views/ABViewGridPopupExport.js
+++ b/AppBuilder/platform/views/ABViewGridPopupExport.js
@@ -7,7 +7,7 @@
 import ClassUI from "../../../ui/ClassUI";
 
 export default class ABWorkObjectPopupExport extends ClassUI {
-   constructor(App, idBase) {
+   constructor(idBase) {
       idBase = idBase || "abviewgridpopupExport";
 
       super({


### PR DESCRIPTION
fixes 11.1 in https://github.com/digi-serve/ns_app/issues/91. Because idbase wasn't passed in properly, our webix ids were clashing