### PR TITLE
Parse tenant->config->options into an object...

### DIFF
--- a/resources/Tenant.js
+++ b/resources/Tenant.js
@@ -14,6 +14,18 @@ class Tenant extends EventEmitter {
    init() {
       var config = Config.tenantConfig();
       if (config) {
+         // check if we have options that are stored as a string
+         if (
+            typeof config.options === "string" ||
+            config.options instanceof String
+         ) {
+            // if we do try to parse them into a JSON object
+            try {
+               config.options = JSON.parse(config.options);
+            } catch (error) {
+               console.error(error);
+            }
+         }
          this._config = config;
          this.textClickToEnter = config.options.textClickToEnter;
       }


### PR DESCRIPTION
When init() of a tenant we are storing the options under the _config. However when coming from the database the options are stored as a string and later on in the file we are trying to read or write to them as if they are a JSON object. This bit of code will check if it is a string and if so attempt to parse it into an object so the methods later on will work as expected.