### PR TITLE
[fix] Catch initialized data emit

### DIFF
--- a/AppBuilder/platform/views/ABViewConditionalContainer.js
+++ b/AppBuilder/platform/views/ABViewConditionalContainer.js
@@ -260,6 +260,11 @@ module.exports = class ABViewConditionalContainer extends (
                eventName: "loadData",
                listener: () => _logic.displayView(),
             });
+            this.eventAdd({
+               emitter: dv,
+               eventName: "initializedData",
+               listener: () => _logic.displayView(),
+            });
 
             this.eventAdd({
                emitter: dv,


### PR DESCRIPTION
If the conditional container only tries to load on `loadData`, data collections which have complicated filters or have cursors set by other DCs will fail to load. (as seen in CARs Edit Child)

Only If there is NO data does line `116` `dv.dataStatusFlag` get checked.

I want to force this to run when there is no data, and in order to do that, the DC needs to be initialized


*critical for* https://github.com/digi-serve/cars_app/pull/76