### PR TITLE
[fix] if no cursor, default to ELSE, and don't load incorrect data

### DIFF
--- a/AppBuilder/platform/views/ABViewConditionalContainer.js
+++ b/AppBuilder/platform/views/ABViewConditionalContainer.js
@@ -279,28 +279,28 @@ module.exports = class ABViewConditionalContainer extends (
       var _logic = {
          displayView: (currData) => {
             let dv = this.datacollection;
-            if (dv) {
+            if (dv && dv.dataStatus === dv.dataStatusFlag.initialized) {
                if (currData == null) {
                   currData = dv.getCursor();
                }
+               var isValid = this.__filterComponent.isValid(currData);
 
-               // show 'waiting' panel
+               // dataStatus initialized
+               // filter is valid
+               // currentData has been loaded from cursor
                if (
-                  !currData &&
-                  (dv.dataStatus == dv.dataStatusFlag.notInitial ||
-                     dv.dataStatus == dv.dataStatusFlag.initializing)
+                  isValid &&
+                  currData != undefined // if , at this point, there is no cursor; the data collection is empty
                ) {
-                  $$(ids.component).showBatch("wait");
-                  return;
+                  // if (isValid && currData) {
+                  $$(ids.component).showBatch("if");
+               } else {
+                  $$(ids.component).showBatch("else");
                }
-            }
-
-            var isValid = this.__filterComponent.isValid(currData);
-            if (isValid) {
-               // if (isValid && currData) {
-               $$(ids.component).showBatch("if");
             } else {
-               $$(ids.component).showBatch("else");
+               // show 'waiting' panel if data is not loaded
+               $$(ids.component).showBatch("wait");
+               return;
             }
          },
       };


### PR DESCRIPTION
The most important addition is that an `undefined` cursor will default to `Else` in a conditional container.
The use case for this is a data collection which becomes empty because of a parent link.

Welcoming ideas on how to do this better, as I have not solved that wrong data shows up when switching between `Children` in `CARs`

Ideally this should put a 'wait' on a conditional widget if the parent `Data Collection` gets changed.

There is, however, some lag for `Prelim Health Info`. Possibly because all DCs don't emit that they are un-initialized all at once?