### PR TITLE
[add] if no filterCon: error and create empty

### DIFF
--- a/AppBuilder/platform/views/ABViewFormConnect.js
+++ b/AppBuilder/platform/views/ABViewFormConnect.js
@@ -215,6 +215,19 @@ module.exports = class ABViewFormConnect extends ABViewFormConnectCore {
          this.datasource ? this.datasource : null
       );
 
+      if (
+         !this.settings.objectWorkspace ||
+         !this.settings.objectWorkspace.filterConditions
+      ) {
+         this.AB.error("Error: filter conditions do not exist", {
+            error: "filterConditions do not exist",
+            view: this,
+         });
+         // manually place an empty filter
+         this.settings["objectWorkspace"] = {};
+         this.settings["objectWorkspace"]["filterConditions"] = { glue: "and" };
+      }
+
       this.__filterComponent.setValue(
          this.settings.objectWorkspace.filterConditions ??
             ABViewFormConnectPropertyComponentDefaults.filterConditions

--- a/AppBuilder/platform/views/ABViewFormConnect.js
+++ b/AppBuilder/platform/views/ABViewFormConnect.js
@@ -221,6 +221,11 @@ module.exports = class ABViewFormConnect extends ABViewFormConnectCore {
       ) {
          this.AB.error("Error: filter conditions do not exist", {
             error: "filterConditions do not exist",
+            viewLocation: {
+               application: this.application.name,
+               id: this.id,
+               name: this.label,
+            },
             view: this,
          });
          // manually place an empty filter


### PR DESCRIPTION
I need this because new definitions from dev.digiserve are dropping the filter conditions: if those filter conditions are empty V2 fails to load.

the ab.error should make it possible to hunt down later