### PR TITLE
do not populate suggest options in onBeforeShow

### DIFF
--- a/AppBuilder/platform/views/ABViewConnectDataFilter.js
+++ b/AppBuilder/platform/views/ABViewConnectDataFilter.js
@@ -6,7 +6,7 @@ const L = (...params) => AB.Multilingual.label(...params);
 class ABViewConnectDataFilterComponent extends ABViewComponent {
    constructor(view, idbase) {
       super(idbase ?? `ABViewConnectDataFilter_${view.id}`, {
-         reset: ""
+         reset: "",
       });
 
       this.view = view;
@@ -59,18 +59,24 @@ class ABViewConnectDataFilterComponent extends ABViewComponent {
 
       const [field] = object.fields((f) => f.columnName == this.settings.field);
       if (!field) {
-         console.warn(`Cannot find field "${this.settings.field}" in ${object.name}`);
-         return
+         this.AB.notify.developer(
+            `Cannot find field "${this.settings.field}" in ${object.name}`,
+            {
+               context: "ABViewConnectDataFilterComponent.init()",
+               data: { settings: this.settings },
+            }
+         );
+         return;
       }
       this.field = field;
 
-      const suggest = {
-         on: {
-            onBeforeShow: function () {
-               field.getAndPopulateOptions(this, null, field);
-            },
-         },
-      };
+      const suggest = webix.ui({
+         view: "suggest",
+         filter: ({ value }, search) =>
+            value.toLowerCase().includes(search.toLowerCase()),
+      });
+      field.getAndPopulateOptions(suggest, null, field);
+
       $$(this.ids.component).define("suggest", suggest);
       $$(this.ids.component).define(
          "label",

--- a/AppBuilder/platform/views/ABViewFormConnect.js
+++ b/AppBuilder/platform/views/ABViewFormConnect.js
@@ -1,11 +1,10 @@
 const ABViewFormConnectCore = require("../../core/views/ABViewFormConnectCore");
-const ABViewPropertyAddPage =
-   require("./viewProperties/ABViewPropertyAddPage").default;
-const ABViewPropertyEditPage =
-   require("./viewProperties/ABViewPropertyEditPage").default;
+const ABViewPropertyAddPage = require("./viewProperties/ABViewPropertyAddPage")
+   .default;
+const ABViewPropertyEditPage = require("./viewProperties/ABViewPropertyEditPage")
+   .default;
 
-const ABViewFormConnectPropertyComponentDefaults =
-   ABViewFormConnectCore.defaultValues();
+const ABViewFormConnectPropertyComponentDefaults = ABViewFormConnectCore.defaultValues();
 
 const ABPopupSort = require("../../../ABDesigner/ab_work_object_workspace_popupSortFields");
 
@@ -931,19 +930,11 @@ module.exports = class ABViewFormConnect extends ABViewFormConnectCore {
          button: true,
          selectAll: multiselect ? true : false,
          body: {
-            data: [],
             template: editForm + "#value#",
          },
-         on: {
-            onShow: () => {
-               field.getAndPopulateOptions(
-                  $$(ids.component),
-                  this.options,
-                  field,
-                  form
-               );
-            },
-         },
+         // Support partial matches
+         filter: ({ value }, search) =>
+            value.toLowerCase().includes(search.toLowerCase()),
       };
 
       component.ui.onClick = {


### PR DESCRIPTION
onShow gets called multiple times with typing, and we clear and load the options each time. This means filtering by text input doesn't work. We only need to load the options once. Also added a more flexible search, so that we can match any part of the label not just the start.

Should also do this on the grid editor, but it's a bit more complicated.