### PR TITLE
fix issue where menu was loaded at bottom of screen

### DIFF
--- a/init/initDiv.js
+++ b/init/initDiv.js
@@ -21,6 +21,10 @@ export default {
          loading.style.alignItems = "center";
          loading.style.display = "flex";
          loading.style.height = "100vh";
+         loading.style.width = "100%";
+         loading.style.position = "absolute";
+         loading.style.top = "0";
+         loading.style.left = "0";
          // loading.style.animation = "spinning 1s ease infinite";
 
          loading.innerHTML = `<svg style="opacity: 0.6; animation: spinning 1s ease infinite; width: 25px; height: 25px;" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--! Font Awesome Pro 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2022 Fonticons, Inc. --><path d="M304 48c0-26.5-21.5-48-48-48s-48 21.5-48 48s21.5 48 48 48s48-21.5 48-48zm0 416c0-26.5-21.5-48-48-48s-48 21.5-48 48s21.5 48 48 48s48-21.5 48-48zM48 304c26.5 0 48-21.5 48-48s-21.5-48-48-48s-48 21.5-48 48s21.5 48 48 48zm464-48c0-26.5-21.5-48-48-48s-48 21.5-48 48s21.5 48 48 48s48-21.5 48-48zM142.9 437c18.7-18.7 18.7-49.1 0-67.9s-49.1-18.7-67.9 0s-18.7 49.1 0 67.9s49.1 18.7 67.9 0zm0-294.2c18.7-18.7 18.7-49.1 0-67.9S93.7 56.2 75 75s-18.7 49.1 0 67.9s49.1 18.7 67.9 0zM369.1 437c18.7 18.7 49.1 18.7 67.9 0s18.7-49.1 0-67.9s-49.1-18.7-67.9 0s-18.7 49.1 0 67.9z"/></svg>`;


### PR DESCRIPTION
This fixes the issue where the menu bar would seemingly be loaded at the bottom of the screen. The issue is traced back to an issue with Webix and popups however the quick fix is to ensure that Webix is only rendering their content into the dimensions of the browser window with no scrolling. The addition of my preloader caused the initial screen to be slightly larger because of an invisible button that was also on the page. These CSS changes should force the preloader to just fit the window.