### PR TITLE
contain images in carousel for better readability

### DIFF
--- a/styles/ui.css
+++ b/styles/ui.css
@@ -838,10 +838,12 @@ input[type="text"].selectivity-multiple-input {
 }
 .ab-carousel-image-container {
    position: relative;
+   height: 100%;
 }
 .ab-carousel-image-container img {
    width: 100%;
-   height: auto;
+   height: 100%;
+   object-fit: contain;
 }
 .ab-carousel-image-title {
    position: absolute;


### PR DESCRIPTION
This fixes the display issue in the carousel where images overflow beyond the boundaries of the widget. 