### PR TITLE
do not show clear button on required select lists

### DIFF
--- a/AppBuilder/platform/dataFields/ABFieldList.js
+++ b/AppBuilder/platform/dataFields/ABFieldList.js
@@ -191,7 +191,7 @@ module.exports = class ABFieldList extends ABFieldListCore {
             }
             if (selectedObj.text) {
                let clear = "";
-               if (options.editable) {
+               if (options.editable && !this.settings.required) {
                   clear = `<span class="webix_multicombo_delete clear-combo-value" role="button" aria-label="Remove item"></span>`;
                }
                values.push(


### PR DESCRIPTION
I found the instance where I would click on a select list's clear button and it would not clear...it was because the select list was a required field. This fix will not include the clear button on select lists if they are required...you can still edit the entry just not allowed to clear it.

so this...
<img width="199" alt="Screen Shot 2022-10-18 at 12 36 10 PM" src="https://user-images.githubusercontent.com/106924/196504335-ada4766f-b81c-4cbe-8b64-a91e2436491c.png">

becomes this...
<img width="233" alt="Screen Shot 2022-10-18 at 12 36 29 PM" src="https://user-images.githubusercontent.com/106924/196504390-f3056c78-3737-4490-8c2b-70c1d3bd75d4.png">
