### PR TITLE
hotfix: okta/cas auth error when visiting /home directly

### DIFF
--- a/init/initConfig.js
+++ b/init/initConfig.js
@@ -40,6 +40,12 @@ export default {
          BS.Config.config(configData);
       } catch (err) {
          BS.error("initConfig: GET /config:", err);
+         // HOTFIX: (12/15/2022) If the user visits /home directly /config is
+         // the first request made to sails and if we're not authenticated but
+         // using OKTA or CAS, we get a CORS error when trying to authenticate.
+         // Send the user to / to get authenticated correctly.
+         if (err.message == "Failed to fetch")
+            window.location.replace(window.location.origin);
       }
    },
 };


### PR DESCRIPTION
Visiting `/home` directly (instead of `/`) causes an error authenticating with Okta and CAS. Probably better ways to fix this, but redirecting them to `/` when we get this error should work.