### PR TITLE
fix passing method as function to CsvImporter

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewCSVImporterComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewCSVImporterComponent.js
@@ -38,7 +38,7 @@ module.exports = class ABViewCSVImporterComponent extends ClassUI {
       // {json}
       // a local copy of the settings for our ABView
 
-      this.csvImporter = new CSVImporter(this.label);
+      this.csvImporter = new CSVImporter((...args) => this.label(...args));
       // {CSVImporter}
       // An instance of the object that imports the CSV data.
 


### PR DESCRIPTION
CsImporter need a label function, but we can't pass `this.label` directly as `this` will be undefined.
prevents opening app in ABDesigner