### PR TITLE
escape `'` in list option ids when building queryselectors

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewFormItemComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormItemComponent.js
@@ -61,8 +61,9 @@ module.exports = class ABViewFormItemComponent extends ABViewComponent {
                   if (!popup) return;
                   this.getList().data.each((option) => {
                      if (!option) return;
+                     // our option.ids are based on builder input and can include the ' character
                      var node = popup.$view.querySelector(
-                        "[webix_l_id='" + option.id + "']"
+                        `[webix_l_id='${option.id.replaceAll("'", "\\'")}']`
                      );
                      if (!node) return;
                      node.setAttribute(


### PR DESCRIPTION
Our `option.ids` are based on builder input and can include the `'` character. So need to escape them here.
Prevented me from opening a component in designer.