### PR TITLE
stop reload form happening on datacollection events.

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewCarouselComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewCarouselComponent.js
@@ -18,7 +18,7 @@ export default class ABViewCarouselComponent extends ABViewComponent {
       };
 
       this._handler_doReload = () => {
-         this.datacollection?.reloadData();
+         // this.datacollection?.reloadData();
       };
 
       this._handler_doFilter = (fnFilter, filterRules) => {


### PR DESCRIPTION
This code causes a reload from the server each time there is a change to a datacollection...the result was that datacollection was reloaded from the server and sometimes the initial cursor would be reset.