### PR TITLE
fix detail multiline dsiplay

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewDetailCustomComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDetailCustomComponent.js
@@ -12,22 +12,7 @@ module.exports = class ABViewDetailCustomComponent extends (
       const field = baseView.field();
       const detailView = baseView.detailComponent();
 
-      let templateLabel = "";
-
-      if (detailView?.settings?.showLabel) {
-         if (detailView.settings.labelPosition === "top")
-            templateLabel =
-               "<label style='display:block; text-align: left;' class='webix_inp_top_label'>#label#</label>";
-         else
-            templateLabel =
-               "<label style='width: #width#px; display: inline-block; float: left; line-height: 32px;'>#label#</label>";
-      }
-
-      const template = (templateLabel + "#result#")
-         // let template = (templateLabel)
-         .replace(/#width#/g, detailView.settings.labelWidth)
-         .replace(/#label#/g, field ? field.label : "")
-         .replace(/#result#/g, field ? field.columnHeader().template({}) : "");
+      let template = field ? field.columnHeader().template({}) : "";
 
       return super.ui({
          minHeight: 45,
@@ -65,6 +50,9 @@ module.exports = class ABViewDetailCustomComponent extends (
       field.customDisplay(rowData, null, node, {
          editable: false,
       });
+      // Hack: remove the extra webix_template class here, which adds padding so
+      // the item is not alligned with the others
+      node.getElementsByClassName("webix_template")[1].removeAttribute("class");
    }
 
    setValue(val) {


### PR DESCRIPTION
fixes #274

Main change is splitting the detail item from a single `webix.template` to a `template` for both the label and value within a row or column based on label position.
```js
ui = {
   cols: [labeTtemplate, valueTemplate]  // or rows:
}
```
![image](https://user-images.githubusercontent.com/10155226/230343497-6ad2365d-d7dc-47f7-9787-c077210869bd.png)
