### PR TITLE
Fix website login problem

### DIFF
--- a/webpack/index.ejs
+++ b/webpack/index.ejs
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<% /*This template is used by webpack to generate an index.html in ab-service-web. It includes the correct hashed app.js*/ %> <!-- see ab_platform_web/src/index.ejs -->
+<% /*This template is used by webpack to generate an index.html in ab-service-web. It includes the correct hashed app.js*/ %> <!-- see ab_platform_web/webpack/index.ejs -->
 <html>
 <head>
   <meta charset="utf-8">
   <title>AppBuilder</title>
-  <style>
-  </style>
+  <link href="/__getCookie" rel="stylesheet" />
   <script type='text/javascript' src='/assets/dependencies/sails.io.js' reconnection="true" ></script>
 </head>
 <body>


### PR DESCRIPTION
## Background

On the VPN sites, users often face the issue where they authenticate with CAS, and then end up in an infinite loop where the website keeps bouncing them back to CAS and back. The "Hello" page stares at them as the browser is stuck reloading forever.

The surface reason for this is that Sails is not sending the session cookie to the browser. With no cookie, the browser cannot prove its identity even after going through CAS. So Sails thinks it's a new unauthenticated user, and redirects to CAS again.

## Root cause?

Something is blocking the session cookie. I spent days looking for it, but have not found it.

The `/favicon.ico` route does set a cookie. Some users can login after clearing the cache and restarting, or even switching to a different browser. (Favicon is not consistently loaded by the browser.) The favicon does not go through the authUser or switcheroo policies. So it seems like the cause might be something in `api_sails/api/policies/authUser.js` (or one of the related files), but I don't know what exactly. After several days of searching and debugging, I am done trying.

## Workaround

Sails has a special route `/__getCookie` that senses if the user has no cookie, then creates a session cookie and sends it to the browser. This does not go through any policies.

So we get the browser to load this route by pretending it is a css stylesheet. I have verified that this works.