### PR TITLE
cleanup old gzip and license files

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -34,7 +34,12 @@ module.exports = {
          publicPath: "/assets",
       }),
       new CleanWebpackPlugin({
-         cleanOnceBeforeBuildPatterns: ["*.js", "*.js.map"],
+         cleanOnceBeforeBuildPatterns: [
+            "*.js",
+            "*.js.map",
+            "*.gz",
+            "*.LICENSE.txt",
+         ],
       }),
       sentryWebpackPlugin({
          authToken: process.env.SENTRY_AUTH_TOKEN,


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- remove old gzip and license files when creating a new webpack build
<!-- /release_notes --> 
