### PR TITLE
Improve webix load

### DIFF
--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -109,7 +109,7 @@ class ABFactory extends ABFactoryCore {
       this.Network = Network;
       this.Storage = Storage;
       this.Tenant = Tenant;
-      this.Webix = Webix;
+      this.Webix = webix;
 
       // Plugin Classes
       this.ClassUI = ClassUI;
@@ -852,7 +852,7 @@ class ABFactory extends ABFactoryCore {
    // Utilities
    //
    alert(options) {
-      Webix.alert(options);
+      this.webix.alert(options);
    }
 
    cloneDeep(value) {

--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -847,7 +847,7 @@ class ABFactory extends ABFactoryCore {
    // Utilities
    //
    alert(options) {
-      this.webix.alert(options);
+      this.Webix.alert(options);
    }
 
    cloneDeep(value) {

--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -39,11 +39,6 @@ import Tenant from "../resources/Tenant.js";
 import UISettings from "./uiSettings/config.js";
 // UISettings: detailed settings for our common UI elements
 
-import Webix from "../js/webix/webix.min.js";
-// NOTE: moved to require() because using import with webix.js
-// really messed things up!
-// var Webix = require("../js/webix/webix.js");
-
 class ABValidator {
    constructor(AB) {
       this.AB = AB;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ io.sails.reconnection = true;
 import "./styles/loader.css";
 import "./js/webix/webix.min.css";
 
-/** @typedef {import("./js/webix/types/webix.global").Webix} Webix */
 import "./styles/ui.css";
 
 import "./init/sentry.js";
@@ -30,7 +29,6 @@ import(
    /* webpackPreload: true */
    "./js/webix/webix.min.js"
 ).then((webix) => {
-   webix.debug({});
    // Make sure webix is global object
    window.webix = webix;
    // Now load additional webix resources

--- a/index.js
+++ b/index.js
@@ -24,13 +24,12 @@ import Bootstrap from "./init/Bootstrap.js";
 // Bootstrap is responsible for initializing the platform.
 
 // Import webix dynamically so we load it before we load other files that need it
-// Don't use minified webix! Webpack will minify it for us and give sourcemaps,
-// making debugging easier
 import(
    /* webpackChunkName: "webix" */
    /* webpackPreload: true */
-   "./js/webix/webix.js"
+   "./js/webix/webix.min.js"
 ).then((webix) => {
+   webix.debug({});
    // Make sure webix is global object
    window.webix = webix;
    // Now load additional webix resources

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ io.sails.reconnection = true;
 
 // Include these .css and .js files as part of our bundle.
 import "./styles/loader.css";
-
-import webix from "./js/webix/webix.min.js";
 import "./js/webix/webix.min.css";
 
 import "./styles/ui.css";
@@ -21,48 +19,39 @@ import "./init/sentry.js";
 // NOTE: keep Font Awesome AFTER webix css so webix wont
 // override our icon styles
 import "./styles/font-awesome.min.css";
-/* eslint-enable no-unused-vars */
 
 import Bootstrap from "./init/Bootstrap.js";
 // Bootstrap is responsible for initializing the platform.
 
-// Import webix components
-import * as gantt from "./js/webix/components/gantt/gantt.min.js";
-import "./js/webix/components/gantt/gantt.min.css";
-
-import * as kanban from "./js/webix/components/kanban/kanban.min.js";
-import * as pivot from "./js/webix/components/pivot/pivot.min.js";
-import * as report from "./js/webix/components/reports/reports.min.js";
-import "./js/webix/components/reports/reports.min.css";
-import "./js/webix/components/query/query.min.css";
-import query from "./js/webix/components/query/query.min.js";
-import * as scheduler from "./js/webix/components/scheduler/scheduler.min.js";
-import "./js/webix/components/scheduler/scheduler.min.css";
-
-// Make sure webix is global object
-if (!window.webix) {
+// Import webix dynamically so we load it before we load other files that need it
+// Don't use minified webix! Webpack will minify it for us and give sourcemaps,
+// making debugging easier
+import(
+   /* webpackChunkName: "webix" */
+   /* webpackPreload: true */
+   "./js/webix/webix.js"
+).then((webix) => {
+   // Make sure webix is global object
    window.webix = webix;
-}
+   // Now load additional webix resources
+   import(
+      /* webpackChunkName: "webix.resources" */
+      /* webpackPreload: true */
+      "./js/webix/webixResources"
+   );
 
-window.gantt = gantt;
-window.kanban = kanban;
-window.pivot = pivot;
-window.reports = report;
-window.scheduler = scheduler;
+   Bootstrap.init().catch((err) => {
+      // This is a known error that has already been handled.
+      if (err.code == "ENODEFS") return;
 
-Bootstrap.init().catch((err) => {
-   // This is a known error that has already been handled.
-   if (err.code == "ENODEFS") return;
+      var errorMSG = err.toString();
 
-   var errorMSG = err.toString();
+      Bootstrap.alert({
+         type: "alert-error",
+         title: "Error initializing Portal:",
+         text: errorMSG,
+      });
 
-   Bootstrap.alert({
-      type: "alert-error",
-      title: "Error initializing Portal:",
-      text: errorMSG,
+      Bootstrap.error(err);
    });
-
-   Bootstrap.error(err);
 });
-
-export default Bootstrap;

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ io.sails.reconnection = true;
 import "./styles/loader.css";
 import "./js/webix/webix.min.css";
 
+/** @typedef {import("./js/webix/types/webix.global").Webix} Webix */
 import "./styles/ui.css";
 
 import "./init/sentry.js";

--- a/init/Bootstrap.js
+++ b/init/Bootstrap.js
@@ -5,18 +5,6 @@
  * well the main ABFactory object that will drive the rest of the applications.
  */
 
-import * as Webix from "../js/webix/webix.min.js";
-// NOTE: changed to require() so switching to webix_debug.js will work.
-// const Webix = require("../js/webix/webix_debug.js");
-
-import webixCSS from "../js/webix/webix.min.css";
-// Make sure webix is global object
-if (!window.webix) {
-   window.webix = Webix;
-}
-
-import "../js/webix/locales/th-TH.js";
-
 import events from "events";
 
 const EventEmitter = events.EventEmitter;
@@ -37,25 +25,8 @@ import initDefinitions from "../init/initDefinitions.js";
 
 // import JSZipUtils from "jszip-utils/dist/jszip-utils.min.js";
 
-// Should use webix/query, querybuilder no longer maintained
-// But we still use this in some places (processing record rules, etc)
-import("../js/webix/components/querybuilder/querybuilder.min.js");
-// We need to do a dynamic import to ensure webix is loaded first
-import "../js/webix/components/querybuilder/querybuilder.min.css";
-
 import Selectivity from "../js/selectivity/selectivity.min.js";
 import selectivityCSS from "../js/selectivity/selectivity.min.css";
-
-import * as tinymce from "../js/webix/extras/tinymce";
-import "tinymce/icons/default";
-import "tinymce/themes/silver";
-import "tinymce/plugins/link";
-import "tinymce/skins/ui/oxide/skin.min.css";
-import "tinymce/skins/ui/oxide/content.css"; // content.min.css ?
-import "tinymce/skins/content/default/content.min.css";
-
-import("../js/webix/components/hint/hint.js");
-import "../js/webix/components/hint/hint.css";
 
 import UI from "../ui/ui.js";
 import PreloadUI from "../ui/loading.js";
@@ -238,7 +209,7 @@ class Bootstrap extends EventEmitter {
                return Promise.resolve().then(() => {
                   // webix recommends wrapping any webix code in the .ready()
                   // function that executes after page loading.
-                  Webix.ready(() => {
+                  webix.ready(() => {
                      const locales = {
                         en: "en-US",
                         "zh-hans": "zh-CN",
@@ -253,7 +224,7 @@ class Bootstrap extends EventEmitter {
                            languageCode
                         ) &&
                         Object.prototype.hasOwnProperty.call(
-                           Webix.i18n.locales,
+                           webix.i18n.locales,
                            locales[languageCode]
                         )
                            ? locales[languageCode]
@@ -265,7 +236,7 @@ class Bootstrap extends EventEmitter {
                      // with the exception that scroll bars appear when user
                      // hovers over a scrollable area
                      /* if (!Webix.env.touch  && Webix.env.scrollSize ) */
-                     Webix.CustomScroll.init();
+                     webix.CustomScroll.init();
 
                      const div = this.div();
 
@@ -286,7 +257,7 @@ class Bootstrap extends EventEmitter {
    }
 
    alert(options) {
-      Webix.alert(options);
+      webix.alert(options);
    }
 
    div(el) {

--- a/js/webix/extras/tinymce.js
+++ b/js/webix/extras/tinymce.js
@@ -1,5 +1,11 @@
-import webix from "../webix.min.js";
 import tinymce from "tinymce";
+import "tinymce/icons/default";
+import "tinymce/themes/silver";
+import "tinymce/plugins/link";
+import "tinymce/skins/ui/oxide/skin.min.css";
+import "tinymce/skins/ui/oxide/content.css"; // content.min.css ?
+import "tinymce/skins/content/default/content.min.css";
+
 webix.protoUI(
    {
       name: "tinymce-editor",

--- a/js/webix/locales/th-TH.js
+++ b/js/webix/locales/th-TH.js
@@ -1,13 +1,8 @@
 /*Thai (Thailand) locale
  * modified to use Budhist Era Years
  */
-import * as Webix from "../webix.min.js";
 
-if (!window.webix) {
-   window.webix = Webix;
-}
-
-window.webix.i18n.locales["th-TH"] = {
+webix.i18n.locales["th-TH"] = {
    groupDelimiter: ",",
    groupSize: 3,
    decimalDelimiter: ".",

--- a/js/webix/webixResources.js
+++ b/js/webix/webixResources.js
@@ -7,8 +7,6 @@
  * Notes:
  * - use `webpackMode: "eager"` comment to include the dynamic import in this
  *   package
- * - use unminified js - webpack will handle minifying in production mode,
- *   and will create sourcemaps to help when debugging
  */
 
 // CSS
@@ -22,28 +20,28 @@ import "./components/hint/hint.css";
 // Components
 import(
    /* webpackMode: "eager" */
-   "./components/gantt/gantt.js"
+   "./components/gantt/gantt.min.js"
 ).then((gantt) => (window.gantt = gantt));
 import "./components/hint/hint.js";
 import(
    /* webpackMode: "eager" */
-   "./components/kanban/kanban.js"
+   "./components/kanban/kanban.min.js"
 ).then((kanban) => (window.kanban = kanban));
 import(
    /* webpackMode: "eager" */
-   "./components/pivot/pivot.js"
+   "./components/pivot/pivot.min.js"
 ).then((pivot) => (window.pivot = pivot));
-import "./components/query/query.js";
+import "./components/query/query.min.js";
 // Should use webix/query, querybuilder no longer maintained
 // But we still use this in some places (processing record rules, etc)
-import "./components/querybuilder/querybuilder.js";
+import "./components/querybuilder/querybuilder.min.js";
 import(
    /* webpackMode: "eager" */
-   "./components/reports/reports.js"
+   "./components/reports/reports.min.js"
 ).then((report) => (window.reports = report));
 import(
    /* webpackMode: "eager" */
-   "./components/scheduler/scheduler.js"
+   "./components/scheduler/scheduler.min.js"
 ).then((scheduler) => (window.scheduler = scheduler));
 
 // Extras

--- a/js/webix/webixResources.js
+++ b/js/webix/webixResources.js
@@ -1,0 +1,53 @@
+/**
+ * webixResources.js
+ * This file should include all extra webix resources (components, locales, etc.)
+ * This will be bundeled by webpack into a single file and loaded as a dynamic
+ * import after webix is loaded.
+ *
+ * Notes:
+ * - use `webpackMode: "eager"` comment to include the dynamic import in this
+ *   package
+ * - use unminified js - webpack will handle minifying in production mode,
+ *   and will create sourcemaps to help when debugging
+ */
+
+// CSS
+import "./components/gantt/gantt.min.css";
+import "./components/reports/reports.min.css";
+import "./components/query/query.min.css";
+import "./components/scheduler/scheduler.min.css";
+import "./components/querybuilder/querybuilder.min.css";
+import "./components/hint/hint.css";
+
+// Components
+import(
+   /* webpackMode: "eager" */
+   "./components/gantt/gantt.js"
+).then((gantt) => (window.gantt = gantt));
+import "./components/hint/hint.js";
+import(
+   /* webpackMode: "eager" */
+   "./components/kanban/kanban.js"
+).then((kanban) => (window.kanban = kanban));
+import(
+   /* webpackMode: "eager" */
+   "./components/pivot/pivot.js"
+).then((pivot) => (window.pivot = pivot));
+import "./components/query/query.js";
+// Should use webix/query, querybuilder no longer maintained
+// But we still use this in some places (processing record rules, etc)
+import "./components/querybuilder/querybuilder.js";
+import(
+   /* webpackMode: "eager" */
+   "./components/reports/reports.js"
+).then((report) => (window.reports = report));
+import(
+   /* webpackMode: "eager" */
+   "./components/scheduler/scheduler.js"
+).then((scheduler) => (window.scheduler = scheduler));
+
+// Extras
+import "./extras/tinymce";
+
+// Locales
+import "./locales/th-TH.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ab_platform_web",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ab_platform_web",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "ISC",
       "dependencies": {
         "@sentry/browser": "^7.69.0",
@@ -40,6 +40,7 @@
         "mocha": "^9.1.2",
         "prettier": "^2.2.1",
         "sinon": "^14.0.0",
+        "source-map-loader": "^4.0.1",
         "style-loader": "^2.0.0",
         "url-loader": "^4.1.1",
         "webpack": "^5.74.0",
@@ -8313,6 +8314,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
+      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -15551,6 +15573,17 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
+    },
+    "source-map-loader": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
+      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.6",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      }
     },
     "source-map-support": {
       "version": "0.5.21",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mocha": "^9.1.2",
     "prettier": "^2.2.1",
     "sinon": "^14.0.0",
+    "source-map-loader": "^4.0.1",
     "style-loader": "^2.0.0",
     "url-loader": "^4.1.1",
     "webpack": "^5.74.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "*.css",
     "./js/webix/extras/tinymce.js",
     "./js/webix/locales/*",
+    "./js/webix/componenets/**/*.js",
+    "./js/webix/extras/*.js",
     "./init/sentry.js"
   ]
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -24,6 +24,11 @@ module.exports = {
             test: /\.(eot|woff|woff2|svg|ttf)([?]?.*)$/,
             use: ["url-loader?limit=10000000"],
          },
+         {
+            test: /\.js$/,
+            enforce: "pre",
+            use: ["source-map-loader"],
+         },
       ],
    },
    plugins: [


### PR DESCRIPTION
Including the webix sourcemaps, which makes debugging much easier.

Also noticed we load webix in multiple places to avoid problems when loading secondary webix files. So I moved all secondary files to a single spot and use dynamic imports to ensure we load webix first.

## Release Notes
<!-- #release_notes -->
- include webix sourcemaps in webpack build
- load webix resources in set order to avoid missing dependencies
<!-- /release_notes --> 
