### PR TITLE
catch uncaught error

### DIFF
--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -826,14 +826,14 @@ class ABFactory extends ABFactoryCore {
     *     Additional related information concerning the issue.
     */
    notify(domain, error, info) {
-      // const scope = new Sentry.Scope();
-      // // Mark builder alerts as lower level in sentry
-      // if (domain == "builder") scope.setLevel("warning");
-      // scope.setTag("domain", domain);
-      // scope.setContext("info", info);
-      // Sentry.captureException(error, scope);
-      // console.error(error);
-      // console.error(info);
+      const scope = new Sentry.Scope();
+      // Mark builder alerts as lower level in sentry
+      if (domain == "builder") scope.setLevel("warning");
+      scope.setTag("domain", domain);
+      scope.setContext("info", info);
+      Sentry.captureException(error, scope);
+      console.error(error);
+      console.error(info);
    }
 
    plugins() {

--- a/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
@@ -176,8 +176,8 @@ module.exports = class ABViewFormButton extends ABViewFormItemComponent {
                this.AB.notifyDeveloper(e, {
                   context:
                      "formButton.onSave > catch err > saveButton.enable()",
-                  buttonID: this.view.id,
-                  formID: this.view.parent.id,
+                  buttonID: this?.view?.id,
+                  formID: this?.view?.parent?.id,
                });
             }
          });

--- a/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
@@ -168,7 +168,18 @@ module.exports = class ABViewFormButton extends ABViewFormItemComponent {
          })
          .catch((err) => {
             console.error(err);
-            saveButton.enable?.();
+            // Catch uncaught error reported in Sentry and add context
+            // APPBUILDER-WEB-1A3(https://appdev-designs.sentry.io/issues/4631880265/)
+            try {
+               saveButton.enable?.();
+            } catch (e) {
+               this.AB.notifyDeveloper(e, {
+                  context:
+                     "formButton.onSave > catch err > saveButton.enable()",
+                  buttonID: this.view.id,
+                  formID: this.view.parent.id,
+               });
+            }
          });
    }
 };


### PR DESCRIPTION
Sentry is catching this error, seems to only happen on accounting.
[APPBUILDER-WEB-1A3](https://appdev-designs.sentry.io/issues/4631880265/)
![image](https://github.com/digi-serve/ab_platform_web/assets/10155226/4e4c4da1-46a2-4c51-b9ca-c3665654d28a)

## Release Notes
<!-- #release_notes -->
- catch an uncaught form error and add context
<!-- /release_notes --> 
