### PR TITLE
[fix] have the delete handler actually call the "delete" event.

### DIFF
--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -66,7 +66,7 @@ module.exports = class ABModel extends ABModelCore {
       };
 
       this.handler_delete = (...params) => {
-         this.handler_common("ab.datacollection.update", ...params);
+         this.handler_common("ab.datacollection.delete", ...params);
       };
 
       this.handler_findAll = (...params) => {


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- [fix] have the delete handler actually call the "delete" event.
<!-- /release_notes --> 


Not sure how we made it this long with not calling the "delete" event.  Maybe when we refactored things we made it so the "update" would also suffice, but we didn't leave any notes here, so I'm guessing it is a mistake.