### PR TITLE
[fix] ABViewFormConnect components that can select multiple values now handle encoded values "val1,val2" properly

### DIFF
--- a/AppBuilder/platform/dataFields/ABFieldUser.js
+++ b/AppBuilder/platform/dataFields/ABFieldUser.js
@@ -163,7 +163,7 @@ module.exports = class ABFieldUser extends ABFieldUserCore {
             val = val.replace(/ab-current-user/g, this.AB.Account.username());
          else if (Array.isArray(val))
             val = val.map((v) =>
-               (v.username ?? v.uuid ?? v.id ?? v)?.replace(
+               (v?.username ?? v?.uuid ?? v?.id ?? v)?.replace(
                   /ab-current-user/g,
                   this.AB.Account.username()
                )
@@ -197,6 +197,20 @@ module.exports = class ABFieldUser extends ABFieldUserCore {
          }
 
          return result;
+      });
+   }
+
+   getOptions(...params) {
+      return super.getOptions(...params).then((options) => {
+         // in a ABFieldUser, our options.id elements need to have
+         // the username, not the .uuid:
+         (options || []).forEach((o) => {
+            if (o.username) {
+               o.id = o.username;
+            }
+         });
+
+         return options;
       });
    }
 };

--- a/AppBuilder/platform/views/viewComponent/ABViewFormComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormComponent.js
@@ -403,6 +403,12 @@ module.exports = class ABViewFormComponent extends ABViewComponent {
             (comp instanceof ABViewFormJson && comp.settings.type === "filter")
       );
 
+      const normalFields = baseView.fieldComponents(
+         (comp) =>
+            comp instanceof ABViewFormItem &&
+            !(comp instanceof ABViewFormCustom)
+      );
+
       // Set default values
       if (!rowData) {
          customFields.forEach((f) => {
@@ -424,20 +430,14 @@ module.exports = class ABViewFormComponent extends ABViewComponent {
             comp?.refresh?.(defaultRowData);
          });
 
-         const normalFields = baseView.fieldComponents(
-            (comp) =>
-               comp instanceof ABViewFormItem &&
-               !(comp instanceof ABViewFormCustom)
-         );
-
          normalFields.forEach((f) => {
+            if (f.key === "button") return;
+
             const field = f.field();
             if (!field) return;
 
             const comp = baseView.viewComponents[f.id];
             if (!comp) return;
-
-            if (f.key === "button") return;
 
             const colName = field.columnName;
 
@@ -460,7 +460,7 @@ module.exports = class ABViewFormComponent extends ABViewComponent {
       }
 
       // Populate value to custom fields
-      else
+      else {
          customFields.forEach((f) => {
             const comp = baseView.viewComponents[f.id];
             if (!comp) return;
@@ -472,6 +472,19 @@ module.exports = class ABViewFormComponent extends ABViewComponent {
 
             comp?.refresh?.(rowData);
          });
+
+         normalFields.forEach((f) => {
+            if (f.key === "button") return;
+
+            const field = f.field();
+            if (!field) return;
+
+            const comp = baseView.viewComponents[f.id];
+            if (!comp) return;
+
+            field.setValue($$(comp.ids.formItem), rowData);
+         });
+      }
 
       this.timerId = null;
    }

--- a/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
@@ -24,6 +24,10 @@ module.exports = class ABViewFormConnectComponent extends (
       return this.view.field();
    }
 
+   get multiselect() {
+      return this.field?.settings.linkType == "many";
+   }
+
    ui() {
       const field = this.field;
       const baseView = this.view;
@@ -39,7 +43,7 @@ module.exports = class ABViewFormConnectComponent extends (
          });
       }
 
-      const multiselect = field.settings.linkType == "many";
+      const multiselect = this.multiselect; // field.settings.linkType == "many";
       const formSettings = form?.settings || {};
       const ids = this.ids;
 
@@ -166,6 +170,12 @@ module.exports = class ABViewFormConnectComponent extends (
       const ids = this.ids;
       const field = this.field;
       const baseView = this.view;
+
+      if (this.multiselect) {
+         if (typeof data == "string") {
+            data = data.split(",");
+         }
+      }
 
       let selectedValues;
       if (Array.isArray(data)) {


### PR DESCRIPTION

## Release Notes
<!-- #release_notes -->
- [fix] ABViewFormConnect components that can select multiple values now handle encoded values "val1,val2" properly
<!-- /release_notes --> 

I was debugging a problem with the display of the Site Administration -> Role -> Assign User form that wouldn't populate the existing data properly in the ABViewFormConnect field.  

Most of the current code related to checking and populating that form component only expected a single value "val1".  However connections that support multiple values will return them encoded as a string "val1,val2"  and our logic would fail to parse those correctly.  