### PR TITLE
Make Network Rest Great Again

### DIFF
--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -49,14 +49,12 @@ function errorPopup(error) {
 function no_socket_trigger(model, key, data) {
    // If we do not have socket updates available, then trigger an
    // update event with this data.
-   // ## NOTE: attempting to see performance difference
-   // ## if we reduce our socket updates
-   // if (model.AB.Network.type() != "socket") {
-   model.AB.emit(key, {
-      objectId: model.object.id,
-      data,
-   });
-   // }
+   if (model.AB.Network.type() != "socket") {
+      model.AB.emit(key, {
+         objectId: model.object.id,
+         data,
+      });
+   }
 }
 
 module.exports = class ABModel extends ABModelCore {

--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -242,6 +242,7 @@ module.exports = class ABModel extends ABModelCore {
             });
       }).then((newVal) => {
          no_socket_trigger(this, "ab.datacollection.create", newVal);
+         return newVal;
       });
    }
 
@@ -268,9 +269,10 @@ module.exports = class ABModel extends ABModelCore {
             errorPopup(err);
             reject(err);
          });
-      }).then(() => {
+      }).then((res) => {
          // properly issue the delete
          no_socket_trigger(this, "ab.datacollection.delete", id);
+         return res;
       });
    }
 
@@ -545,6 +547,7 @@ module.exports = class ABModel extends ABModelCore {
       }).then((newVal) => {
          // properly issue the update
          no_socket_trigger(this, "ab.datacollection.update", newVal);
+         return newVal;
       });
    }
 

--- a/AppBuilder/platform/ABObject.js
+++ b/AppBuilder/platform/ABObject.js
@@ -719,11 +719,13 @@ module.exports = class ABObject extends ABObjectCore {
       // report both OUR warnings, and any warnings from any of our fields
       var allWarnings = super.warningsAll();
       this.fields().forEach((f) => {
-         allWarnings = allWarnings.concat(f.warnings());
+         if (!f) return;
+         allWarnings = allWarnings.concat(f?.warnings());
       });
 
       this.indexes().forEach((i) => {
-         allWarnings = allWarnings.concat(i.warnings());
+         if (!i) return;
+         allWarnings = allWarnings.concat(i?.warnings());
       });
 
       return allWarnings.filter((w) => w);
@@ -747,11 +749,11 @@ module.exports = class ABObject extends ABObjectCore {
       });
 
       allFields.forEach((f) => {
-         f.warningsEval();
+         f?.warningsEval();
       });
 
       this.indexes().forEach((i) => {
-         i.warningsEval();
+         i?.warningsEval();
       });
    }
 

--- a/AppBuilder/platform/dataFields/ABFieldConnect.js
+++ b/AppBuilder/platform/dataFields/ABFieldConnect.js
@@ -818,11 +818,15 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
          $list.refresh();
       }
 
-      item.setValue(
-         Array.isArray(val)
-            ? val.map((e) => e.id ?? e.uuid ?? e).join(",")
-            : val.id ?? val.uuid ?? val
-      );
+      // try to prevent form flicker:
+      // Only reset the value if the value changes:
+      let currVal = item.getValue();
+      let newVal = Array.isArray(val)
+         ? val.map((e) => e.id ?? e.uuid ?? e).join(",")
+         : val.id ?? val.uuid ?? val;
+      if (currVal != newVal) {
+         item.setValue(newVal);
+      }
    }
 
    /**

--- a/AppBuilder/platform/dataFields/ABFieldUser.js
+++ b/AppBuilder/platform/dataFields/ABFieldUser.js
@@ -175,8 +175,18 @@ module.exports = class ABFieldUser extends ABFieldUserCore {
 
    setValue(item, rowData) {
       let val = rowData[this.columnName];
-      // Select "[Current user]" to update
-      if (val == "ab-current-user") val = this.AB.Account.username();
+
+      if (this.linkType() == "many") {
+         // val should be an array.
+         // if any of those contain "ab-current-user" replace it:
+         val = val.map((v) =>
+            v == "ab-current-user" ? this.AB.Account.username() : v
+         );
+      } else {
+         // val is a single entry string
+         // Select "[Current user]" to update
+         if (val == "ab-current-user") val = this.AB.Account.username();
+      }
 
       rowData[this.columnName] = val;
 
@@ -212,5 +222,35 @@ module.exports = class ABFieldUser extends ABFieldUserCore {
 
          return options;
       });
+   }
+
+   pullRelationValues(row) {
+      let values = super.pullRelationValues(row);
+      // remember, our .id == .username
+
+      if (Array.isArray(values)) {
+         values = values.map((v) => {
+            v.id = v.username || v.id;
+            return v;
+         });
+      } else {
+         values.id = values.username || values.id;
+      }
+
+      return values;
+   }
+
+   pullRecordRelationValues(record) {
+      let data = super.pullRecordRelationValues(record);
+      if (Array.isArray(data)) {
+         data = data.map((d) => {
+            d.id = d.username ?? d.id;
+            return d;
+         });
+      } else {
+         data.id = data.username || data.id;
+      }
+
+      return data;
    }
 };

--- a/AppBuilder/platform/views/ABViewForm.js
+++ b/AppBuilder/platform/views/ABViewForm.js
@@ -16,9 +16,6 @@ const L = (...params) => AB.Multilingual.label(...params);
 // let PopupRecordRule = null;
 // let PopupSubmitRule = null;
 
-////
-//// LEFT OFF HERE: Review and Refactor
-////
 const ABViewFormPropertyComponentDefaults = ABViewFormCore.defaultValues();
 
 module.exports = class ABViewForm extends ABViewFormCore {
@@ -515,7 +512,7 @@ module.exports = class ABViewForm extends ABViewFormCore {
          );
       });
 
-      await Promise.all(tasks)
+      await Promise.all(tasks);
 
       return true;
    }

--- a/AppBuilder/platform/views/viewComponent/ABViewCarouselComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewCarouselComponent.js
@@ -143,8 +143,10 @@ export default class ABViewCarouselComponent extends ABViewComponent {
       dv.on("initializedData", this._handler_ready);
 
       if (this.settings.filterByCursor) {
-         dv.removeListener("changeCursor", this._handler_doOnShow);
-         dv.on("changeCursor", this._handler_doOnShow);
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            dv.removeListener(key, this._handler_doOnShow);
+            dv.on(key, this._handler_doOnShow);
+         });
       }
 
       const baseView = this.view;
@@ -213,7 +215,9 @@ export default class ABViewCarouselComponent extends ABViewComponent {
       dv.removeListener("initializedData", this._handler_ready);
 
       if (this.settings.filterByCursor)
-         dv.removeListener("changeCursor", this._handler_doOnShow);
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            dv.removeListener(key, this._handler_doOnShow);
+         });
 
       this.filterUI.removeListener("filter.data", this._handler_doOnShow);
    }

--- a/AppBuilder/platform/views/viewComponent/ABViewChartComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewChartComponent.js
@@ -19,23 +19,28 @@ module.exports = class ABViewChartComponent extends ABViewContainerComponent {
       if (dc) {
          const eventNames = [
             "changeCursor",
+            "cursorStale",
             "create",
             "update",
             "delete",
             "initializedData",
          ];
 
-         if (
-            dc.datacollectionLink &&
-            !("changeCursor" in (dc.datacollectionLink._events ?? []))
-         )
-            baseView.eventAdd({
-               emitter: dc.datacollectionLink,
-               eventName: "changeCursor",
-               listener: () => {
-                  baseView.refreshData();
-               },
-            });
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            // QUESTION: is this a problem if the check !(key in (...)) finds
+            // an event that some OTHER widget has added and not this one?
+            if (
+               dc.datacollectionLink &&
+               !(key in (dc.datacollectionLink._events ?? []))
+            )
+               baseView.eventAdd({
+                  emitter: dc.datacollectionLink,
+                  eventName: key,
+                  listener: () => {
+                     baseView.refreshData();
+                  },
+               });
+         });
 
          eventNames.forEach((evtName) => {
             baseView.eventAdd({

--- a/AppBuilder/platform/views/viewComponent/ABViewConditionalContainerComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewConditionalContainerComponent.js
@@ -83,16 +83,12 @@ module.exports = class ABViewConditionalContainerComponent extends (
             listener: () => this.displayView(), // Q? does this need to remain empty param?
          });
 
-         baseView.eventAdd({
-            emitter: dc,
-            eventName: "changeCursor",
-            listener: (...p) => this.displayView(...p),
-         });
-
-         baseView.eventAdd({
-            emitter: dc,
-            eventName: "cursorStale",
-            listener: (...p) => this.displayView(...p),
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            baseView.eventAdd({
+               emitter: dc,
+               eventName: key,
+               listener: (...p) => this.displayView(...p),
+            });
          });
       }
 

--- a/AppBuilder/platform/views/viewComponent/ABViewConditionalContainerComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewConditionalContainerComponent.js
@@ -88,6 +88,12 @@ module.exports = class ABViewConditionalContainerComponent extends (
             eventName: "changeCursor",
             listener: (...p) => this.displayView(...p),
          });
+
+         baseView.eventAdd({
+            emitter: dc,
+            eventName: "cursorStale",
+            listener: (...p) => this.displayView(...p),
+         });
       }
 
       this.displayView();

--- a/AppBuilder/platform/views/viewComponent/ABViewDetailComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDetailComponent.js
@@ -43,10 +43,12 @@ module.exports = class ABViewDetailComponent extends ABViewContainerComponent {
 
          if (currData) this.displayData(currData);
 
-         this.eventAdd({
-            emitter: dv,
-            eventName: "changeCursor",
-            listener: (...p) => this.displayData(...p),
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            this.eventAdd({
+               emitter: dv,
+               eventName: key,
+               listener: (...p) => this.displayData(...p),
+            });
          });
 
          this.eventAdd({

--- a/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
@@ -2068,14 +2068,23 @@ export default class ABViewGridComponent extends ABViewComponent {
     *        rowData.id should match an existing entry.
     */
    selectRow(rowData) {
-      const $DataTable = this.getDataTable();
+      let id = rowData?.id ?? rowData;
+      if (this.__timeout_selectRow) {
+         console.log("Duplicate selectRow():", id);
+         clearTimeout(this.__timeout_selectRow);
+      }
+      this.__timeout_selectRow = setTimeout(() => {
+         const $DataTable = this.getDataTable();
+         if (!$DataTable) return;
 
-      if (!$DataTable) return;
+         if (!id) $DataTable.unselect();
+         else if (id && $DataTable.exists(id)) {
+            $DataTable.select(id, false);
+            $DataTable.showItem(id);
+         } else $DataTable.select(null, false);
 
-      if (!rowData) $DataTable.unselect();
-      else if (rowData?.id && $DataTable.exists(rowData.id))
-         $DataTable.select(rowData.id, false);
-      else $DataTable.select(null, false);
+         this.__timeout_selectRow = null;
+      }, 15);
    }
 
    /**

--- a/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
@@ -150,7 +150,9 @@ export default class ABViewGridComponent extends ABViewComponent {
 
    detatch() {
       this.view.filterHelper.removeAllListeners("filter.data");
-      this.datacollection?.removeListener("changeCursor", this.handler_select);
+      ["changeCursor", "cursorStale"].forEach((key) => {
+         this.datacollection?.removeListener(key, this.handler_select);
+      });
    }
 
    /**
@@ -1585,10 +1587,12 @@ export default class ABViewGridComponent extends ABViewComponent {
       const dv = this.datacollection;
 
       if (dv)
-         this.eventAdd({
-            emitter: dv,
-            eventName: "changeCursor",
-            listener: this.handler_select.bind(this),
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            this.eventAdd({
+               emitter: dv,
+               eventName: key,
+               listener: this.handler_select.bind(this),
+            });
          });
    }
 

--- a/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
@@ -2078,7 +2078,7 @@ export default class ABViewGridComponent extends ABViewComponent {
          if (!$DataTable) return;
 
          if (!id) $DataTable.unselect();
-         else if (id && $DataTable.exists(id)) {
+         else if ($DataTable.exists(id)) {
             $DataTable.select(id, false);
             $DataTable.showItem(id);
          } else $DataTable.select(null, false);

--- a/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
@@ -150,7 +150,7 @@ export default class ABViewGridComponent extends ABViewComponent {
 
    detatch() {
       this.view.filterHelper.removeAllListeners("filter.data");
-      ["changeCursor", "cursorStale"].forEach((key) => {
+      ["changeCursor", "cursorStale", "cursorSelect"].forEach((key) => {
          this.datacollection?.removeListener(key, this.handler_select);
       });
    }
@@ -1587,7 +1587,7 @@ export default class ABViewGridComponent extends ABViewComponent {
       const dv = this.datacollection;
 
       if (dv)
-         ["changeCursor", "cursorStale"].forEach((key) => {
+         ["changeCursor", "cursorStale", "cursorSelect"].forEach((key) => {
             this.eventAdd({
                emitter: dv,
                eventName: key,

--- a/AppBuilder/platform/views/viewComponent/ABViewTextComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewTextComponent.js
@@ -55,12 +55,15 @@ module.exports = class ABViewTextComponent extends ABViewComponent {
       const dataview = this.datacollection;
       const baseView = this.view;
 
-      if (dataview && baseView.parent.key !== "dataview")
-         baseView.eventAdd({
-            emitter: dataview,
-            eventName: "changeCursor",
-            listener: (...p) => this.displayText(...p),
+      if (dataview && baseView.parent.key !== "dataview") {
+         ["changeCursor", "cursorStale"].forEach((key) => {
+            baseView.eventAdd({
+               emitter: dataview,
+               eventName: key,
+               listener: (...p) => this.displayText(...p),
+            });
          });
+      }
 
       this.displayText();
    }

--- a/init/Bootstrap.js
+++ b/init/Bootstrap.js
@@ -208,9 +208,8 @@ class Bootstrap extends EventEmitter {
 
       if (!window.AB) window.AB = this.AB;
       // Make our Factory Global.
-      // Transition: we still have some UI code that depends on accessing
-      // our Factory as a Global var.  So until those are rewritten we will
-      // make our factory Global.
+      // NOTE: our tests are expecting to access our ABFactory this way.
+
       this.AB.Network.registerNetworkTestWorker(
          networkTestWorker,
          networkIsSlow


### PR DESCRIPTION
We had certain dependencies on the client of depending on the Socket Updates to properly update our local client data.  

however, this won't display the application correctly when we set out Network = "rest".  So these changes should enable a local client app to properly update itself without the input of socket updates.

## Release Notes
<!-- #release_notes -->
- [fix] have the client trigger local datacollection update handlers when we modify data.
- [fix] patch additional ABFieldUser quirks when working with values that need .id = .username
- [sync] with appropriate changes to core
<!-- /release_notes --> 
