### PR TITLE
fix syntax for network warning during preload

### DIFF
--- a/init/Bootstrap.js
+++ b/init/Bootstrap.js
@@ -97,7 +97,7 @@ class Bootstrap extends EventEmitter {
             const $uiWarning = document.getElementById(
                "preload_network_warning"
             );
-            networkIsSlow ? $uiWarning.show() : $uiWarning.hide();
+            $uiWarning.hidden = !networkIsSlow;
             // Tell sentry our network speed changed
             performance.setContext("breadcrumb", {
                category: "network",


### PR DESCRIPTION
[APPBUILDER-WEB-1PD](https://appdev-designs.sentry.io/issues/4927522791/)


## Release Notes
<!-- #release_notes -->
- Fix slow network warning display while the site is loading ([APPBUILDER-WEB-1PD](https://appdev-designs.sentry.io/issues/4927522791/))
<!-- /release_notes --> 
