### PR TITLE
hotfix: err: refused to execute script ... MIME type 'text/html'

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const APP = path.resolve(__dirname);
-const HtmlWebpackPlugin = require("html-webpack-plugin");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 
 module.exports = {
@@ -28,11 +27,6 @@ module.exports = {
       ],
    },
    plugins: [
-      new HtmlWebpackPlugin({
-         template: "./webpack/index.ejs",
-         filename: path.join(APP, "..", "web", "assets", "index.html"),
-         inject: "body",
-      }),
       new CleanWebpackPlugin({
          cleanOnceBeforeBuildPatterns: [
             "*.js",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,5 +1,8 @@
+const path = require("path");
+const APP = path.resolve(__dirname);
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
 
 module.exports = merge(common, {
@@ -14,6 +17,11 @@ module.exports = merge(common, {
       ],
    },
    plugins: [
+      new HtmlWebpackPlugin({
+         template: "./webpack/index.ejs",
+         filename: path.join(APP, "..", "web", "assets", "index.html"),
+         inject: "body",
+      }),
       new webpack.DefinePlugin({
          WEBPACK_MODE: JSON.stringify("development"),
          VERSION: JSON.stringify(process.env.npm_package_version),

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,8 +1,11 @@
+const path = require("path");
+const APP = path.resolve(__dirname);
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 const CompressionPlugin = require("compression-webpack-plugin");
 const Critters = require("critters-webpack-plugin");
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
 const webpack = require("webpack");
@@ -18,6 +21,20 @@ module.exports = merge(common, {
       ],
    },
    plugins: [
+      new HtmlWebpackPlugin({
+         template: "./webpack/index.ejs",
+         filename: path.join(APP, "..", "web", "assets", "index.html"),
+         inject: "body",
+         minify: {
+            collapseWhitespace: true,
+            keepClosingSlash: true,
+            removeComments: true,
+            removeRedundantAttributes: true,
+            removeScriptTypeAttributes: false,
+            removeStyleLinkTypeAttributes: true,
+            useShortDoctype: true,
+         },
+      }),
       new CompressionPlugin({
          exclude: /index\.ejs/,
       }),


### PR DESCRIPTION
The default html compression used in `html-webpack-plugin` will remove script type tags. In production tell the plugin not to remove these.

## Release Notes
<!-- #release_notes -->
- Fix error loading `/config/preloader` because of incorrect MIME type
<!-- /release_notes --> 
