### PR TITLE
hotfix: webix form css in production

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -30,7 +30,7 @@ module.exports = merge(common, {
          ),
       }),
       new Critters({
-         pruneSource: true,
+         pruneSource: false,
          preload: "swap",
       }),
       sentryWebpackPlugin({


### PR DESCRIPTION
Caused by pruning webix css that we use in the preload screen UI.
https://github.com/digi-serve/ns_app/issues/393
## Release Notes
<!-- #release_notes -->
- fix: form display issue 
<!-- /release_notes -->