### PR TITLE
Fix setting data-cy on a connected record form field

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
@@ -612,19 +612,26 @@ module.exports = class ABViewFormConnectComponent extends (
 
       $node.refresh();
 
-      this.busy();
-      await field.getAndPopulateOptions(
-         // $node,
-         $formItem,
-         baseView.options,
-         field,
-         baseView.parentFormComponent()
-      );
-      this.ready();
-
       // Add data-cy attributes
       const dataCy = `${field.key} ${field.columnName} ${field.id} ${baseView.parent.id}`;
       node.setAttribute("data-cy", dataCy);
+
+      this.busy();
+      try {
+         await field.getAndPopulateOptions(
+            // $node,
+            $formItem,
+            baseView.options,
+            field,
+            baseView.parentFormComponent()
+         );
+      } catch (err) {
+         this.AB.notify.developer(err, {
+            context:
+               "ABViewFormConnectComponent > onShow() error calling field.getAndPopulateOptions",
+         });
+      }
+      this.ready();
 
       // Need to refresh selected values when they are custom index
       this._onChange($formItem.getValue());


### PR DESCRIPTION
I don't fully understand why be it appears that in some cases the await for `field.getAndPopulateOptions` doesn't resolve.
I'm seeing this locally and it causing issues with the test https://github.com/digi-serve/kitchensink_app/pull/101.

The form field still functions correctly. And just switching the order fixes the missing data-cy attributes. 

## Release Notes
<!-- #release_notes -->
- fix setting data-cy attributes on form connect fields
<!-- /release_notes --> 
