### PR TITLE
Fix the clear selection UI on connected fields.

### DIFF
--- a/styles/ui.css
+++ b/styles/ui.css
@@ -98,7 +98,6 @@ label {
 .webix_multicombo_tag,
 .webix_multicombo_value {
    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.3);
-   padding: 0 9pt;
    border-bottom: 1px solid #fff;
    margin: 3px 3px 1px;
    max-height: 27px;
@@ -131,15 +130,8 @@ label {
 .webix_multicombo_delete:hover {
    transform: scale(1.1);
 }
-.webix_multicombo_delete {
-   margin-right: -7pt;
-}
 .webix_multicombo_delete.clear-combo-value {
-   margin-right: -5px;
-   position: relative;
-   right: 9px;
    transition: all 0.2s ease-in-out;
-   top: 13px;
 }
 .webix_multicombo_value {
    display: flex;


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Fix UI for clearing a value of a connected field.
<!-- /release_notes --> 

Current UI:
<img width="149" alt="Screenshot 2024-03-21 at 3 27 12 PM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/b06f2333-2f3c-4119-94b6-1dd09b0caedb">

After Fix:
<img width="156" alt="Screenshot 2024-03-21 at 3 25 58 PM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/dde66107-441b-4d5a-9b69-6f61d67ad52b">


## Test Status
No test needed because it is a small CSS change to help an element not be partial covered.