### PR TITLE
Fix UI displaying connected fields with "Add New" buttons when label position is "top"

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
@@ -133,23 +133,42 @@ module.exports = class ABViewFormConnectComponent extends (
             },
          };
 
-         _ui = {
-            inputId: ids.formItem,
-            rows: [
-               {
-                  cols: [
-                     {
-                        view: "label",
-                        label: field.label,
-                        width: formSettings.labelWidth,
-                        align: "left",
-                     },
-                     apcUI,
-                     _ui,
-                  ],
-               },
-            ],
-         };
+         if (_ui.labelPosition == "top") {
+            debugger;
+            _ui = {
+               inputId: ids.formItem,
+               rows: [
+                  {
+                     view: "label",
+                     label: field.label,
+                     // width: formSettings.labelWidth,
+                     align: "left",
+                  },
+                  {
+                     height: 38,
+                     cols: [apcUI, _ui],
+                  },
+               ],
+            };
+         } else {
+            _ui = {
+               inputId: ids.formItem,
+               rows: [
+                  {
+                     cols: [
+                        {
+                           view: "label",
+                           label: field.label,
+                           width: formSettings.labelWidth,
+                           align: "left",
+                        },
+                        apcUI,
+                        _ui,
+                     ],
+                  },
+               ],
+            };
+         }
 
          _ui = super.ui(_ui);
       } else {

--- a/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
@@ -134,7 +134,6 @@ module.exports = class ABViewFormConnectComponent extends (
          };
 
          if (_ui.labelPosition == "top") {
-            debugger;
             _ui = {
                inputId: ids.formItem,
                rows: [

--- a/styles/ui.css
+++ b/styles/ui.css
@@ -98,7 +98,6 @@ label {
 .webix_multicombo_tag,
 .webix_multicombo_value {
    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.3);
-   padding: 0 9pt;
    border-bottom: 1px solid #fff;
    margin: 3px 3px 1px;
    max-height: 27px;
@@ -131,15 +130,8 @@ label {
 .webix_multicombo_delete:hover {
    transform: scale(1.1);
 }
-.webix_multicombo_delete {
-   margin-right: -7pt;
-}
 .webix_multicombo_delete.clear-combo-value {
-   margin-right: -5px;
-   position: relative;
-   right: 9px;
    transition: all 0.2s ease-in-out;
-   top: 13px;
 }
 .webix_multicombo_value {
    display: flex;


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Right now there is no code to show the label of a connected field on top of the field in the form when there is an "Add New" button displayed. Therefore when forms are trying to display using label position "top" they do not look correct when displaying connected fields that have "add new" buttons.
<!-- /release_notes --> 

Current UI:
<img width="684" alt="Screenshot 2024-03-21 at 3 31 38 PM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/ada269bd-cfa3-49f2-ac8b-72f107252085">

New UI:
<img width="689" alt="Screenshot 2024-03-21 at 3 47 49 PM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/c3e609f8-6420-406b-94fd-72ffe216d408">


## Test Status
No test, this just just rearranging UI elements for specific scenarios.
