### PR TITLE
Fix spacing on connected fields labels.

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormConnectComponent.js
@@ -141,7 +141,7 @@ module.exports = class ABViewFormConnectComponent extends (
                   {
                      view: "label",
                      label: field.label,
-                     // width: formSettings.labelWidth,
+                     // height: 22,
                      align: "left",
                   },
                   {


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Fix label spacing on connected fields when "top" label position is used.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
No test needed this is just a visual fix.

<img width="706" alt="Screenshot 2024-03-28 at 9 38 40 AM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/caaea341-fa45-4610-ae86-ad179189e012">

and when it happens multiple times it looks like this...
<img width="920" alt="Screenshot 2024-03-28 at 9 44 22 AM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/4aa64eb5-8edb-456f-8bd3-cf3bf9c43c9a">

new code will help it look like this...
<img width="704" alt="Screenshot 2024-03-28 at 9 38 13 AM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/54fd909d-c8a3-486f-93e4-eee4f72b66c0">
