### PR TITLE
Fix extra space when connected item does not have delete icon.

### DIFF
--- a/js/webix/webix.css
+++ b/js/webix/webix.css
@@ -7264,7 +7264,7 @@ body.webix_print {
   border-radius: 100px;
   padding: 0 12px 0 12px;
 }
-.webix_multicombo_value {
+.webix_multicombo_value:has(> .webix_multicombo_delete) {
   padding: 0 26px 0 12px;
 }
 .webix_multicombo_delete {


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Only add padding on the left of a connected value's container when delete icon is present.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
This is just a visual adjustment. Not test needed.

Removes the extra space like this...
<img width="500" alt="Screenshot 2024-03-28 at 3 22 41 PM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/70a1b6a5-fd21-4f7e-93ad-d74872644fd6">

To look like this...
<img width="508" alt="Screenshot 2024-03-28 at 3 22 15 PM" src="https://github.com/digi-serve/ab_platform_web/assets/106924/035cfaf4-2ddc-43f9-b87c-923929f528f7">
