### PR TITLE
Adjust webix loading in parellel with init

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ import Bootstrap from "./init/Bootstrap.js";
 // Bootstrap is responsible for initializing the platform.
 
 // Import webix dynamically so we load it before we load other files that need it
-import(
+const webixLoading = import(
    /* webpackChunkName: "webix" */
    /* webpackPreload: true */
    "./js/webix/webix.min.js"
@@ -32,12 +32,12 @@ import(
       /* webpackPreload: true */
       "./js/webix/webixResources"
    );
+});
 
-   // __AB_preload should be created by our /config/preload script that gets
-   // loaded on the initial page load.
-   await window.__AB_preload;
-
-   Bootstrap.init().catch((err) => {
+// __AB_preload should be created by our /config/preload script that gets
+// loaded on the initial page load.
+window.__AB_preload.then(() => {
+   Bootstrap.init(webixLoading).catch((err) => {
       // This is a known error that has already been handled.
       if (err.code == "ENODEFS") return;
 

--- a/init/Bootstrap.js
+++ b/init/Bootstrap.js
@@ -19,8 +19,8 @@ import initUser from "../init/initUser.js";
 
 // import JSZipUtils from "jszip-utils/dist/jszip-utils.min.js";
 
-import Selectivity from "../js/selectivity/selectivity.min.js";
-import selectivityCSS from "../js/selectivity/selectivity.min.css";
+// import Selectivity from "../js/selectivity/selectivity.min.js";
+// import selectivityCSS from "../js/selectivity/selectivity.min.css";
 
 import UI from "../ui/ui.js";
 import ErrorNoDefsUI from "../ui/error_noDefs.js";
@@ -58,13 +58,10 @@ class Bootstrap extends EventEmitter {
       });
    }
 
-   async init(ab) {
-      // We rerun init after a sucessful login, at that point we already have AB.
-      // This means we can use `AB.Network` over the fetch API when loading
-      // config again. This prevents the session from being reset, which was
-      // happening inconsitently.
-      if (ab) this.AB = ab;
-
+   /**
+    * @param {Promise} webixLoading - so we know when webix is finished loading
+    */
+   async init(webixLoading) {
       const loadABFactory = import(
          /* webpackChunkName: "AB" */
          /* webpackPrefetch: true */
@@ -183,6 +180,7 @@ class Bootstrap extends EventEmitter {
          networkIsSlow
       );
       await this.AB.init();
+      await webixLoading;
       // NOTE: special case: User has no Roles defined.
       // direct them to our special ErrorNoDefsUI
       if (userInfo && userInfo.roles.length == 0) {


### PR DESCRIPTION
Don't wait for webix to load before starting bootstrap

## Release Notes
<!-- #release_notes -->
- Adjustment to speed a site loading 
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
Covered in existing tests.