### PR TITLE
Fix: prevent undefined values from causing ABFieldUser.pullRelationValues() from crashing

### DIFF
--- a/AppBuilder/platform/dataFields/ABFieldUser.js
+++ b/AppBuilder/platform/dataFields/ABFieldUser.js
@@ -236,15 +236,19 @@ module.exports = class ABFieldUser extends ABFieldUserCore {
 
    pullRelationValues(row) {
       let values = super.pullRelationValues(row);
-      // remember, our .id == .username
 
+      // remember, our .id == .username
       if (Array.isArray(values)) {
+         // prevent any null or undefined:
+         values = values.filter((v) => v);
          values = values.map((v) => {
             v.id = v.username || v.id;
             return v;
          });
       } else {
-         values.id = values.username || values.id;
+         if (values) {
+            values.id = values.username || values.id;
+         }
       }
 
       return values;

--- a/resources/NetworkRestSocket.js
+++ b/resources/NetworkRestSocket.js
@@ -105,6 +105,10 @@ class NetworkRestSocket extends NetworkRest {
       console.warn(JSON.stringify(HashSocketJobs, null, 4));
    }
 
+   socketLogClear() {
+      HashSocketJobs = {};
+   }
+
    ////
    //// Network Utilities
    ////


### PR DESCRIPTION
A little bug I noticed while debugging.

## Release Notes
<!-- #release_notes -->
- [fix] prevent undefined values from causing ABFieldUser.pullRelationValues() from crashing
<!-- /release_notes --> 
