### PR TITLE
Fix errors where Form submissions can reset other connections

### DIFF
--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -901,6 +901,10 @@ class ABFactory extends ABFactoryCore {
       });
    }
 
+   isNil(value) {
+      return _.isNil(value);
+   }
+
    /**
     * @method rules.isUUID
     * evaluate a given value to see if it matches the format of a uuid

--- a/AppBuilder/platform/dataFields/ABFieldConnect.js
+++ b/AppBuilder/platform/dataFields/ABFieldConnect.js
@@ -781,19 +781,24 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
    }
 
    getValue(item) {
+      let val = item.getValue();
       var multiselect = this.settings.linkType == "many";
       if (multiselect) {
          let vals = [];
-         if (item.getValue()) {
-            let val = item.getValue().split(",");
+         if (val) {
+            val = val.split(",");
             val.forEach((record) => {
-               vals.push(item.getList().getItem(record));
+               // make sure we are returning the .uuid values and
+               // not full {Record} values.
+               vals.push(this.getRelationValue(item.getList().getItem(record)));
             });
          }
+
          return vals;
       } else {
-         if (item.getValue()) {
-            return item.getList().getItem(item.getValue());
+         if (val) {
+            // return just the .uuid and not the full {Record}
+            return this.getRelationValue(item.getList().getItem(val));
          } else {
             return "";
          }

--- a/AppBuilder/platform/views/viewComponent/ABViewTabComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewTabComponent.js
@@ -569,8 +569,8 @@ module.exports = class ABViewTabComponent extends ABViewComponent {
             vc.component.onShow();
 
          if (settings.stackTabs && vc?.view?.id === viewId) {
-            $$(viewId).show(false, false);
-            $sidebar.select(`${viewId}_menu`);
+            $$(viewId)?.show(false, false);
+            $sidebar?.select(`${viewId}_menu`);
          }
       });
    }


### PR DESCRIPTION
OK, James and Prin noticed an error on the Digiserve site where adding a connected row in a form would remove the connection on another record.

On the site, it was due to sending the whole `{Record}` back as the value, instead of just the `{uuid}` of the entry.  This patch ensures we are sending back the relevant `{uuid}` value.

## Release Notes
<!-- #release_notes -->
- [fix] be sure to return just the proper uuid and not a full {Record} on ABFieldConnect values
- [fix] prevent bug when viewId is undefined
- [wip] adding an isNil() utilitiy for ABFactory
<!-- /release_notes --> 

## Test Status
This new [Test](https://github.com/digi-serve/kitchensink_app/pull/107) is to validate this submission.  
NOTE: the combo test also validates partial correct operation.
