### PR TITLE
Listen to DataCollection to know if it is empty and update UI

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewDetailComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDetailComponent.js
@@ -44,7 +44,7 @@ module.exports = class ABViewDetailComponent extends ABViewContainerComponent {
 
          if (currData) this.displayData(currData);
 
-         ["changeCursor", "cursorStale"].forEach((key) => {
+         ["changeCursor", "cursorStale", "collectionEmpty"].forEach((key) => {
             this.eventAdd({
                emitter: dv,
                eventName: key,


### PR DESCRIPTION
This is the second part of an update that fixes a bug with the Details View.

https://github.com/digi-serve/ab_platform_web/issues/502

## Release Notes
<!-- #release_notes -->
- Listen when DataCollection is empty to update Details View.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
