### PR TITLE
Fix form clear button from messing with follow cursors

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewComponent.js
@@ -182,8 +182,17 @@ export default class ABViewComponent extends ClassUI {
 
       if (!dc) return;
 
-      if (dc.dataStatus === dc.dataStatusFlag.notInitial)
-         // load data when a widget is showing
-         dc.loadData();
+      // ABViewDocXBuilderComponents can send back [dc,...]
+      if (!Array.isArray(dc)) {
+         if (dc.dataStatus === dc.dataStatusFlag.notInitial)
+            // load data when a widget is showing
+            dc.loadData();
+      } else {
+         dc.forEach((d) => {
+            if (d.dataStatus === d.dataStatusFlag.notInitial)
+               // load data when a widget is showing
+               d.loadData();
+         });
+      }
    }
 }

--- a/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
@@ -137,9 +137,11 @@ module.exports = class ABViewFormButton extends ABViewFormItemComponent {
       // get ABDatacollection
       const dc = form.datacollection;
 
-      // clear cursor of DC
-      dc?.setCursor(null);
-      dc?.setStaticCursor(); // unless it should be static
+      // clear cursor of DC if not set to follow another
+      if (!dc?.isCursorFollow) {
+         dc?.setCursor(null);
+      }
+      // dc?.setStaticCursor(); // unless it should be static
 
       cancelButton?.getFormView?.().clear();
 

--- a/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormButtonComponent.js
@@ -139,6 +139,7 @@ module.exports = class ABViewFormButton extends ABViewFormItemComponent {
 
       // clear cursor of DC
       dc?.setCursor(null);
+      dc?.setStaticCursor(); // unless it should be static
 
       cancelButton?.getFormView?.().clear();
 

--- a/AppBuilder/platform/views/viewComponent/ABViewFormComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormComponent.js
@@ -379,6 +379,7 @@ module.exports = class ABViewFormComponent extends ABViewComponent {
          }
 
          // pull data of current cursor
+         await dc.waitReady();
          const rowData = dc.getCursor();
 
          if ($form) dc.bind($form);

--- a/AppBuilder/platform/views/viewComponent/ABViewFormComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewFormComponent.js
@@ -379,7 +379,7 @@ module.exports = class ABViewFormComponent extends ABViewComponent {
          }
 
          // pull data of current cursor
-         await dc.waitReady();
+         // await dc.waitReady();
          const rowData = dc.getCursor();
 
          if ($form) dc.bind($form);


### PR DESCRIPTION
## Major Fix 1: 
One of the errors happening on the Design digiserve.org site was when a Form `[cancel]` button was pressed, it wanted to set the DataCollection's cursor to null.

This happens to be problematic on DCs where it is a follow Cursor, and the DC that is being followed is based on a Query.

In effect, once the cancel button `.setCursor(null)` on the DC, the DC is unable to re-establish a proper value for future form loads.  

This change simply prevents the form from `.setCursor(null)` on this type of DC.

## Major Fix 2: 
I included a patch to ensure that when our Network Queues requests, we can properly save and retrieve the promise `resolve` and `reject` handlers.  Before, those handlers were getting lost (not able to serialize them) and even though we could make the requests, we were unable to continue the program flow of processing those calls.


## Release Notes
<!-- #release_notes -->
- [wip] make sure a form will wait for it's DC to be ready before attempting to load it's data.
- [fix] prevent loss of Promise context when serializing our network jobs into a queue
- [wip] issue queued network packets in parallel
- [fix] prevent infinite loop while ensuring static cursor is set
- [fix] case where ABViewDocXBuilder returns an array of datacollections
<!-- /release_notes --> 

## Test Status
No new test created.  Probably should have several though:
- test the Network disconnect and reconnect able to process our requests 
- test a DC.follow -> DC(based on Query) scenario with a Form Cancel.  Look at the FCFHRApp -> Edit Person for a model.


Fix #507 

Also might fix https://github.com/digi-serve/ns_app/issues/451