### PR TITLE
We need to pass forUpdate param otherwise the UUID of the connection …

### DIFF
--- a/AppBuilder/platform/dataFields/ABFieldConnect.js
+++ b/AppBuilder/platform/dataFields/ABFieldConnect.js
@@ -790,7 +790,11 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
             val.forEach((record) => {
                // make sure we are returning the .uuid values and
                // not full {Record} values.
-               vals.push(this.getRelationValue(item.getList().getItem(record)));
+               vals.push(
+                  this.getRelationValue(item.getList().getItem(record), {
+                     forUpdate: true,
+                  })
+               );
             });
          }
 


### PR DESCRIPTION
…is sent instead of the selected record's UUID

Related to this Issue:
https://github.com/digi-serve/ab_platform_web/issues/509

## Release Notes
<!-- #release_notes -->
- Fix a bug when updating M:1 records.
<!-- /release_notes --> 