### PR TITLE
hotfix look at cursor set for current data collection

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewDocxBuilderComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDocxBuilderComponent.js
@@ -215,6 +215,7 @@ module.exports = class ABViewDocxBuilderComponent extends ABViewComponent {
                new Promise((resolve, reject) => {
                   const obj = dc.datasource;
                   const objModel = obj.model();
+                  const dcCursor = dc.getCursor();
                   const dcValues = [];
 
                   // pull the defined sort values
@@ -224,8 +225,21 @@ module.exports = class ABViewDocxBuilderComponent extends ABViewComponent {
                   let wheres = this.AB.cloneDeep(
                      dc.settings.objectWorkspace.filterConditions ?? {}
                   );
-                  // if we pass new wheres with a reload use them instead
-                  if (dc.__reloadWheres) {
+                  // if there is a selected cursor set the filter here
+                  if (dcCursor) {
+                     // if there is a selected cursor set the filter here
+                     wheres = {
+                        glue: "and",
+                        rules: [
+                           {
+                              key: obj.PK(),
+                              rule: "equals",
+                              value: dcCursor[obj.PK()],
+                           },
+                        ],
+                     };
+                  } else if (dc.__reloadWheres) {
+                     // if we pass new wheres with a reload use them instead
                      wheres = dc.__reloadWheres;
                   }
                   wheres.glue = wheres.glue || "and";


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Fix bug where we should only load single record when cursor is set on a datacollection used in Docx.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
