### PR TITLE
ensure that data we are looking at is an array

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewDocxBuilderComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDocxBuilderComponent.js
@@ -499,6 +499,9 @@ module.exports = class ABViewDocxBuilderComponent extends ABViewComponent {
       const images = {};
       const tasks = [];
       const addDownloadTask = (fieldImage, data = []) => {
+         if (Array.isArray(data) == false) {
+            data = [data];
+         }
          data.forEach((d) => {
             const imageVal = fieldImage.format(d);
 


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Fix issue where two data collections are in a repot and one has only a single object as a value and the other has an array of objects.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
