### PR TITLE
Fix Form.io data for passed in arrays

### DIFF
--- a/webix_custom_components/formioPreview.js
+++ b/webix_custom_components/formioPreview.js
@@ -34,6 +34,10 @@ module.exports = class ABCustomFormIOPreview extends ABLazyCustomComponent {
             var formComponents = config.formComponents ?? {};
             var formData = config.formData ?? {};
             const component = $$(config.id);
+
+            // JOHNNY: we now have formio designs where we need to pull out
+            // more than just an .id from connected fields. Let's no longer
+            // do this:
             // // we need to find out when we are passing an array of objects and reduce it down to an array of IDs
             // for (var data in formData) {
             //    if (

--- a/webix_custom_components/formioPreview.js
+++ b/webix_custom_components/formioPreview.js
@@ -34,15 +34,15 @@ module.exports = class ABCustomFormIOPreview extends ABLazyCustomComponent {
             var formComponents = config.formComponents ?? {};
             var formData = config.formData ?? {};
             const component = $$(config.id);
-            // we need to find out when we are passing an array of objects and reduce it down to an array of IDs
-            for (var data in formData) {
-               if (
-                  Array.isArray(formData[data]) &&
-                  typeof formData[data][0] == "object"
-               ) {
-                  formData[data] = formData[data].map((item) => item.id);
-               }
-            }
+            // // we need to find out when we are passing an array of objects and reduce it down to an array of IDs
+            // for (var data in formData) {
+            //    if (
+            //       Array.isArray(formData[data]) &&
+            //       typeof formData[data][0] == "object"
+            //    ) {
+            //       formData[data] = formData[data].map((item) => item.id);
+            //    }
+            // }
 
             const form = new Form(component.$view, formComponents);
             // readOnly: true


### PR DESCRIPTION
We previously assumed that passed in arrays would just be needing the .ids of the items.  However, we now have Form.io templates that are displaying embedded data from these records.

So we no longer simplify the array data to just .ids.
