### PR TITLE
Fixes to Team Chart

### DIFF
--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -130,6 +130,8 @@ class ABFactory extends ABFactoryCore {
          }
       };
 
+      this.performance = performance;
+
       this.UISettings = UISettings;
 
       this.Validation = {

--- a/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
@@ -19,8 +19,8 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                teamFormTitle: "",
                teamFormInactive: "",
             },
-            ids,
-         ),
+            ids
+         )
       );
       this.__filters = {};
    }
@@ -70,7 +70,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       const OrgChart = (this.OrgChart = orgChartLoader.default);
       const _oldOnDragStart = OrgChart.prototype._onDragStart;
       OrgChart.prototype._onDragStart = (event) => {
-         event.dataTransfer.setData("isnode", 1)
+         event.dataTransfer.setData("isnode", 1);
          _oldOnDragStart.call(this.__orgchart, event);
       };
       this.ready();
@@ -137,13 +137,17 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                   },
                   populate: true,
                })
-            ).data,
+            ).data
          );
       }
       const contentGroupByField = contentObj?.fieldByID(
-         settings.contentGroupByField,
+         settings.contentGroupByField
       );
-      const contentGroupOptions = contentGroupByField?.settings.options || [];
+      const { data: contentGroupOptions } = await this.AB.objectByID(
+         contentGroupByField?.settings.linkObject
+      )
+         .model()
+         .findAll();
       const contentGroupOptionsLength = contentGroupOptions.length;
       const contentGroupByFieldColumnName = contentGroupByField?.columnName;
       const contentFieldLinkColumnName = contentFieldLink?.columnName;
@@ -167,7 +171,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                dataTransfer.setData("dataPK", dataset.pk);
                dataTransfer.setData(
                   "contentLinkedFieldId",
-                  dataset.contentLinkedFieldId,
+                  dataset.contentLinkedFieldId
                );
                break;
             default:
@@ -191,14 +195,14 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          const $group = event.currentTarget;
          const newGroupText = $group.dataset.text;
          const newNodeDataPK = JSON.parse(
-            $group.parentElement.parentElement.dataset.source,
+            $group.parentElement.parentElement.dataset.source
          )._rawData[nodeObjPK];
          let updatedData = dataTransfer.getData("source");
          this.__orgchart.innerHTML = "";
          if (updatedData === "") {
             const dataPK = dataTransfer.getData("dataPK");
             const contentLinkedFieldID = dataTransfer.getData(
-               "contentLinkedFieldId",
+               "contentLinkedFieldId"
             );
             const contentLinkedField =
                contentObj.fieldByID(contentLinkedFieldID);
@@ -323,7 +327,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                         label: fieldLabel,
                      };
                }
-            }),
+            })
          );
          contentFormElements.push({
             view: "button",
@@ -353,17 +357,16 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                for (const editContentFieldToCreateNew of editContentFieldsToCreateNew) {
                   const editContentFieldToCreateNewColumnName =
                      contentObj.fieldByID(
-                        editContentFieldToCreateNew,
+                        editContentFieldToCreateNew
                      ).columnName;
                   if (
                      JSON.stringify(
-                        newFormData[editContentFieldToCreateNewColumnName] ??
-                           "",
+                        newFormData[editContentFieldToCreateNewColumnName] ?? ""
                      ) !==
                      JSON.stringify(
                         contentDataRecord[
                            editContentFieldToCreateNewColumnName
-                        ] ?? "",
+                        ] ?? ""
                      )
                   ) {
                      this.__orgchart.innerHTML = "";
@@ -459,9 +462,12 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                $content.appendChild($group);
                const groupStyle = $group.style;
                groupStyle["height"] = `${averageHeight}%`;
-               const groupColor = group.hex;
+               // TODO: should this be a config option
+               const groupColor =
+                  group.name === "Leader" ? "#003366" : "#DDDDDD";
                groupStyle["backgroundColor"] = groupColor;
-               const groupText = group.text;
+               // TODO: should this be a config option
+               const groupText = group.name;
                $group.setAttribute("data-text", groupText);
                if (showGroupTitle) {
                   const $groupTitle = element("div", "team-group-title");
@@ -485,10 +491,10 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                   const contentDataRecord =
                      contentDataRecords[contentDataRecordIndex];
                   if (
-                     contentDataRecord[contentFieldLinkColumnName] !==
+                     contentDataRecord[contentFieldLinkColumnName] !=
                         currentNodeDataRecordPK ||
-                     contentDataRecord[contentGroupByFieldColumnName] !==
-                        groupText
+                     contentDataRecord[contentGroupByFieldColumnName] !=
+                        group.id
                   ) {
                      contentDataRecordIndex++;
                      continue;
@@ -500,7 +506,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                   const $rowData = element("div", "team-group-record");
                   $rowData.setAttribute(
                      "data-source",
-                     JSON.stringify(contentDataRecord),
+                     JSON.stringify(contentDataRecord)
                   );
                   $groupContent.appendChild($rowData);
                   $rowData.addEventListener("click", async () => {
@@ -521,7 +527,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                      const displayedObj = AB.objectByID(objID);
                      const displayedObjPK = displayedObj.PK();
                      const displayedField = displayedObj.fieldByID(
-                        contentDisplayedFields[displayedFieldKey],
+                        contentDisplayedFields[displayedFieldKey]
                      );
                      switch (objID) {
                         case contentObjID:
@@ -571,17 +577,15 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                      }
                      const $currentDisplay = element(
                         "div",
-                        "team-group-record-display",
+                        "team-group-record-display"
                      );
                      $rowData.appendChild($currentDisplay);
                      const displayedFieldColumnName = displayedField.columnName;
                      while (currentDataRecords.length > 0)
                         $currentDisplay.appendChild(
                            document.createTextNode(
-                              currentDataRecords.pop()[
-                                 displayedFieldColumnName
-                              ],
-                           ),
+                              currentDataRecords.pop()[displayedFieldColumnName]
+                           )
                         );
                      currentField = null;
                   }
@@ -596,7 +600,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
             $buttons.append($editButton, $addButton);
             const dataID = this.teamRecordID(data.id);
             const values = this.datacollection.getData(
-               (e) => e.id === dataID,
+               (e) => e.id === dataID
             )[0];
             $addButton.onclick = () => {
                this.teamForm("Add", { __parentID: dataID });
@@ -626,12 +630,12 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          orgchart.addEventListener("nodedropped.orgchart", async (event) => {
             const eventDetail = event.detail;
             const dragedRecord = JSON.parse(
-               eventDetail.draggedNode.dataset.source,
+               eventDetail.draggedNode.dataset.source
             )._rawData;
             dragedRecord[
                // Parent node definition.
                this.AB.definitionByID(
-                  this.getSettingField("teamLink").settings.linkColumn,
+                  this.getSettingField("teamLink").settings.linkColumn
                ).columnName
             ] = JSON.parse(eventDetail.dropZone.dataset.source)._rawData.id;
             await nodeModel.update(dragedRecord.id, dragedRecord);
@@ -665,7 +669,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                await dc.waitForDataCollectionToInitialize(dc);
                const panelObj = dc.datasource;
                const contentFieldID = panelObj.connectFields(
-                  (field) => field.datasourceLink.id === contentObjID,
+                  (field) => field.datasourceLink.id === contentObjID
                )[0].fieldLink.id;
                dataPanelUIs.push({
                   header: dataPanelDCs[key],
@@ -685,7 +689,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                               for (const $itemElement of $itemElements) {
                                  $itemElement.setAttribute(
                                     "data-content-linked-field-id",
-                                    contentFieldID,
+                                    contentFieldID
                                  );
                                  $itemElement.setAttribute(
                                     "data-pk",
@@ -693,18 +697,18 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                                        (e) =>
                                           e.id ===
                                           $itemElement.getAttribute(
-                                             "webix_l_id",
-                                          ),
-                                    )[0][panelObj.PK()],
+                                             "webix_l_id"
+                                          )
+                                    )[0][panelObj.PK()]
                                  );
                                  $itemElement.setAttribute("draggable", "true");
                                  $itemElement.addEventListener(
                                     "dragstart",
-                                    fnContentDragStart,
+                                    fnContentDragStart
                                  );
                                  $itemElement.addEventListener(
                                     "dragend",
-                                    fnContentDragEnd,
+                                    fnContentDragEnd
                                  );
                               }
                            });
@@ -740,7 +744,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       let topNode = dc?.getCursor();
       if (view.settings.topTeam) {
          const topNodeColumn = this.AB.definitionByID(
-            view.settings.topTeam,
+            view.settings.topTeam
          ).columnName;
          const topFromFeild = dc.getData((e) => e[topNodeColumn] === 1)[0];
          topNode = topFromFeild ? topFromFeild : topNode;
@@ -749,13 +753,13 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       const teamLink = this.getSettingField("teamLink").columnName;
       const teamName = this.getSettingField("teamName").columnName;
       const teamInactive = this.getSettingField("teamInactive").columnName;
-      const strategy = this.getSettingField("teamStrategy").columnName;
+      const strategyField = this.getSettingField("teamStrategy").columnName;
       const strategyCode = this.getSettingField("strategyCode").columnName;
       const chartData = (this._chartData = {});
       chartData.name = topNode[teamName] ?? "";
       chartData.id = this.teamNodeID(topNode.id);
       chartData.className = `strategy-${
-         topNode[`${strategy}__relation`]?.[strategyCode]
+         topNode[`${strategyField}__relation`]?.[strategyCode]
       }`;
       chartData.isInactive = topNode[teamInactive];
       chartData._rawData = topNode;
@@ -765,15 +769,16 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          if (depth >= maxDepth) return;
          node.children = [];
          node._rawData[teamLink].forEach((id) => {
-            const childData = dc.getData((e) => e.id === id)[0];
+            const childData = dc.getData((e) => e.id == id)[0];
             // Don't show inactive teams
             if (
-               (filters?.inactive !== 1 && childData[teamInactive]) ||
-               childData == null
+               !childData ||
+               (filters?.inactive !== 1 && childData[teamInactive])
             )
                return;
-            const code = childData[`${strategy}__relation`]?.[strategyCode];
-            const strategyClass = `strategy-${code}`;
+            const strategy = childData[`${strategyField}__relation`];
+
+            const strategyClass = `strategy-${strategy[strategyCode]}`;
             const child = {
                name: childData[teamName],
                id: self.teamNodeID(id),
@@ -781,7 +786,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                isInactive: childData[teamInactive],
                _rawData: childData,
             };
-            child.filteredOut = self.filterTeam(filters, child, code);
+            child.filteredOut = self.filterTeam(filters, child, strategy.id);
             if (child.name === "External Support")
                child.className = `strategy-external`;
             if (childData[teamLink].length > 0) {
@@ -798,7 +803,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          } else {
             // sort children alphaetically
             node.children = node.children.sort((a, b) =>
-               a.name > b.name ? 1 : -1,
+               a.name > b.name ? 1 : -1
             );
          }
          return;
@@ -825,7 +830,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       let $popup = $$(this.ids.filterPopup);
       if (!$popup) {
          const [strategyField] = this.datacollection.datasource.fields(
-            (f) => f.id == this.view.settings["teamStrategy"],
+            (f) => f.id == this.view.settings["teamStrategy"]
          );
          const strategyOptions = await strategyField.getOptions();
 
@@ -880,7 +885,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       // Apply filters (match using or)
       if (filters.strategy || filters.teamName) {
          let filter = true;
-         if (filters.strategy !== "" && filters.strategy === code) {
+         if (filters.strategy !== "" && filters.strategy == code) {
             filter = false;
          }
          if (
@@ -909,7 +914,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       const colors = this.settings.strategyColors;
       for (let key in colors) {
          css.push(
-            `org-chart .strategy-${key} .title{background:${colors[key]} !important;}`,
+            `org-chart .strategy-${key} .title{background:${colors[key]} !important;}`
          );
       }
       const style = document.createElement("style");
@@ -921,11 +926,11 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       const { id } = await this.datacollection.model.create(values);
 
       const linkField = this.AB.definitionByID(
-         this.getSettingField("teamLink").settings.linkColumn,
+         this.getSettingField("teamLink").settings.linkColumn
       ).columnName;
       const nameField = this.getSettingField("teamName").columnName;
       const parent = document.querySelector(
-         `#${this.teamNodeID(values[linkField])}`,
+         `#${this.teamNodeID(values[linkField])}`
       );
       const hasChild = parent.parentNode.colSpan > 1;
       const newChild = {
@@ -1015,12 +1020,12 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       let $teamFormPopup = $$(this.ids.teamFormPopup);
       const inactive = this.getSettingField("teamInactive").columnName;
       const linkField = this.AB.definitionByID(
-         this.getSettingField("teamLink").settings.linkColumn,
+         this.getSettingField("teamLink").settings.linkColumn
       ).columnName;
       if (!$teamFormPopup) {
          const nameField = this.getSettingField("teamName");
          const [strategyField] = this.datacollection.datasource.fields(
-            (f) => f.id == this.view.settings["teamStrategy"],
+            (f) => f.id == this.view.settings["teamStrategy"]
          );
          const strategyOptions = await strategyField.getOptions();
          $teamFormPopup = webix.ui({
@@ -1081,7 +1086,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                               const values = $$(this.ids.teamForm).getValues();
                               const strategy = strategyOptions.find(
                                  (f) =>
-                                    f.id === values[strategyField.columnName],
+                                    f.id === values[strategyField.columnName]
                               );
                               if (values.id) {
                                  this.teamEdit(values, strategy);


### PR DESCRIPTION
- fix data types 
    - Select List -> Connected Record
    - Compare `string` and `integer` ids
 - start to look at performance, takes ~2s to load
![image](https://github.com/user-attachments/assets/b8ed67a6-f2fc-448d-8fe0-1611c981ffe2)
    - slowest loading the assignments 

Related: https://github.com/digi-serve/plugin_ABDesigner/pull/274
## Release Notes
<!-- #release_notes -->
- 
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
