### PR TITLE
add better condition checks for query and datacollection conditions

### DIFF
--- a/AppBuilder/platform/FilterComplex.js
+++ b/AppBuilder/platform/FilterComplex.js
@@ -386,8 +386,8 @@ module.exports = class FilterComplex extends FilterComplexCore {
                   }
                   // and it needs to reference a valid DC
                   if (isComplete) {
-                     let obj = this.AB.datacollectionByID(cond.value);
-                     if (!obj) {
+                     let dc = this.AB.datacollectionByID(cond.value);
+                     if (!dc) {
                         isComplete = false;
                      }
                   }
@@ -401,9 +401,32 @@ module.exports = class FilterComplex extends FilterComplexCore {
                   }
                   // and it needs to reference a valid query
                   if (isComplete) {
-                     let obj = this.AB.queryByID(cond.value);
-                     if (!obj) {
+                     let query = this.AB.queryByID(cond.value);
+                     if (!query) {
                         isComplete = false;
+                     }
+                  }
+                  break;
+
+               case "in_query_field":
+               case "not_in_query_field":
+                  // a value needs to exist
+                  if (!cond.value || cond.value == "") {
+                     isComplete = false;
+                  }
+                  // and it needs to reference a valid query
+                  if (isComplete) {
+                     let queryId = cond.value.split(":")[0],
+                        fieldId = cond.value.split(":")[1];
+                     let query = this.AB.queryByID(queryId);
+                     if (!query) {
+                        isComplete = false;
+                     } else {
+                        // and a valid field
+                        let field = query.fieldByID(fieldId);
+                        if (!field) {
+                           isComplete = false;
+                        }
                      }
                   }
                   break;

--- a/AppBuilder/platform/FilterComplex.js
+++ b/AppBuilder/platform/FilterComplex.js
@@ -378,6 +378,36 @@ module.exports = class FilterComplex extends FilterComplexCore {
                   // value
                   break;
 
+               case "in_data_collection":
+               case "not_in_data_collection":
+                  // a value needs to exist
+                  if (!cond.value || cond.value == "") {
+                     isComplete = false;
+                  }
+                  // and it needs to reference a valid DC
+                  if (isComplete) {
+                     let obj = this.AB.datacollectionByID(cond.value);
+                     if (!obj) {
+                        isComplete = false;
+                     }
+                  }
+                  break;
+
+               case "in_query":
+               case "not_in_query":
+                  // a value needs to exist
+                  if (!cond.value || cond.value == "") {
+                     isComplete = false;
+                  }
+                  // and it needs to reference a valid query
+                  if (isComplete) {
+                     let obj = this.AB.queryByID(cond.value);
+                     if (!obj) {
+                        isComplete = false;
+                     }
+                  }
+                  break;
+
                default:
                   // The rest do need a .value
                   if (!cond.value || cond.value == "") {

--- a/AppBuilder/platform/FilterComplex.js
+++ b/AppBuilder/platform/FilterComplex.js
@@ -526,7 +526,7 @@ module.exports = class FilterComplex extends FilterComplexCore {
          const rule = _this._fnBaseGetValue.call(this);
          if (!rule) {
             // Not sure if its a problem, so report in case it is.
-            this.AB.notify.developer(new Error("No rule found"), {
+            _this.AB.notify.developer(new Error("No rule found"), {
                context: "No rule from $filterView.GetValue()",
             });
             return;


### PR DESCRIPTION
Intended for issue [ns_app#543](https://github.com/digi-serve/ns_app/issues/543) 

My solution is to not only verify that a `.value` exists, but that it actually references a current query/datacollection.

Should probably also find additional condition types that fall into this category as well.

## Release Notes
<!-- #release_notes -->
- [wip] add additional condition checks for datacollection and query conditions
- [fix] improper reference to this
- [wip] include in_query_field as well
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
