### PR TITLE
Prevent User Fields from being treated like Connected fields in Record Rule Updater

### DIFF
--- a/AppBuilder/rules/ruleActions/ABViewRuleActionObjectUpdater.js
+++ b/AppBuilder/rules/ruleActions/ABViewRuleActionObjectUpdater.js
@@ -931,7 +931,7 @@ module.exports = class ABViewRuleActionObjectUpdater extends ABViewRuleAction {
 
          // in the case of a connected Field, we use op.value to get the
          // datacollection, and find it's currently selected value:
-         if (field.isConnection || op.valueType == "exist") {
+         if ((field.isConnection && !field.isUser) || op.valueType == "exist") {
             // NOTE: 30 May 2018 :current decision from Ric is to limit this
             // to only handle 1:x connections where we update the current obj
             // with the PK of the value from the DC.
@@ -944,7 +944,10 @@ module.exports = class ABViewRuleActionObjectUpdater extends ABViewRuleAction {
             const dataCollection = this.currentForm.AB.datacollectionByID(
                op.value
             );
-            if (!dataCollection) return;
+            if (!dataCollection) {
+               isUpdated = false;
+               return;
+            }
 
             // we don't want to mess with the dataView directly since it might
             // be used by other parts of the system and this refresh might reset


### PR DESCRIPTION
This is a fix for [ns_app#542](https://github.com/digi-serve/ns_app/issues/542).

This also requires this [PR](https://github.com/digi-serve/appbuilder_class_core/pull/274) as part of the fix.

In our `v2` code, User fields are now Connected fields.  But the Record Rule Updater step didn't properly take that into consideration.

## Release Notes
<!-- #release_notes -->
- [fix] prevent Record Rule Updater from treating User fields as ordinary Connected Fields
<!-- /release_notes --> 

