### PR TITLE
Teams performance improvements.

### DIFF
--- a/AppBuilder/platform/dataFields/ABFieldConnect.js
+++ b/AppBuilder/platform/dataFields/ABFieldConnect.js
@@ -244,7 +244,7 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
     *
     * @return {Promise}
     */
-   async getOptions(whereClause, term, sort, editor) {
+   async getOptions(whereClause, term, sort, editor, populate = false) {
       const theEditor = editor;
 
       if (theEditor) {
@@ -383,7 +383,7 @@ module.exports = class ABFieldConnect extends ABFieldConnectCore {
                   return linkedModel.findAll({
                      where: where,
                      sort: sort,
-                     populate: false,
+                     populate,
                   });
                };
 

--- a/AppBuilder/platform/views/viewComponent/ABViewDataSelectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDataSelectComponent.js
@@ -20,6 +20,7 @@ export default class ABViewDataSelectComponent extends ABViewComponent {
             id: this.ids.select,
             on: {
                onChange: (n, o) => {
+                  if (!o) return;
                   if (n !== o) this.cursorChange(n);
                },
             },

--- a/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
@@ -1678,9 +1678,12 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                               {
                                  view: "template",
                                  id: this.ids.teamFormSubmit,
-                                 template: "#value#",
+                                 template: `<button class="team-form-button" #disabled#>${this.label(
+                                    "Submit"
+                                 )}</button>`,
+                                 data: { disabled: "disabled" },
+                                 borderless: true,
                                  height: 31,
-                                 css: "team-form-button",
                                  onClick: {
                                     "team-form-button": () => {
                                        const values = $$(
@@ -1704,6 +1707,22 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                            ],
                         },
                      ],
+                     on: {
+                        onChange: () => {
+                           const values = $$(this.ids.teamForm).getValues();
+                           const valid =
+                              !!values[strategyField.columnName] &&
+                              !!values[nameField.columnName];
+                           if (valid)
+                              $$(this.ids.teamFormSubmit).setValues({
+                                 disabled: "",
+                              });
+                           else
+                              $$(this.ids.teamFormSubmit).setValues({
+                                 disabled: "disabled",
+                              });
+                        },
+                     },
                   },
                ],
             },
@@ -1716,8 +1735,11 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       $$(this.ids.teamFormTitle).setValues({
          value: `${this.label(mode)} Team`,
       });
-      $$(this.ids.teamFormSubmit).setValues({ value: this.label("Submit") });
       $$(this.ids.teamForm).setValues(values);
+      $$(this.ids.teamFormSubmit).setValues({
+         disabled: "disabled",
+      });
+
       this.teamCanInactivate(values)
          ? $$(this.ids.teamFormInactive).enable()
          : $$(this.ids.teamFormInactive).disable();

--- a/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
@@ -33,6 +33,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
       const ids = this.ids;
       const _ui = super.ui([
          {
+            id: ids.chartView,
             view: "template",
             template: `<div id="${ids.chartDom}"></div>`,
             css: {
@@ -78,6 +79,44 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          _oldOnDragStart.call(this.__orgchart, event);
       };
       this.ready();
+      // SKELETON CHART
+      const orgchart = new OrgChart({
+         data: { title: "", children: [{}, {}] },
+         chartContainer: `#${this.ids.chartDom}`,
+         nodeContent: "title",
+         createNode: ($node) => {
+            // __AUTO_GENERATED_PRINT_VAR_START__
+            console.log("loadOrgChartJs#(anon) node:", $node); // __AUTO_GENERATED_PRINT_VAR_END__
+            $node.querySelector(".title").remove();
+            $node.querySelector(".content").innerHTML = "";
+
+            $node.classList.add("team-node-skeleton");
+         },
+      });
+      const chartDom = document.querySelector(`#${this.ids.chartDom}`);
+      chartDom.textContent = "";
+      chartDom.innerHTML = "";
+      const ui = {
+         cols: [
+            {
+               rows: [
+                  {
+                     view: "template",
+                     height: 50,
+                  },
+                  {
+                     view: "template",
+                     scroll: "auto",
+                  },
+               ],
+            },
+         ],
+      };
+      const $chartContent = AB.Webix.ui(ui).$view;
+      chartDom.appendChild($chartContent);
+      const $chartContentLayout = $chartContent.children[0];
+      $chartContentLayout.children[1].children[0].appendChild(orgchart);
+      this.loadContentData()
    }
 
    async onShow() {

--- a/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
@@ -1608,26 +1608,39 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
             id: this.ids.teamFormPopup,
             close: true,
             position: "center",
-            css: { "border-radius": "10px" },
+            css: { "border-radius": "15px" },
             body: {
+               type: "clean",
                rows: [
                   {
                      view: "toolbar",
                      id: "myToolbar",
-                     css: "webix_dark",
+                     borderless: true,
+                     css: {
+                        background: "#1a3e72",
+                     },
                      cols: [
+                        { width: 5 },
                         {
-                           view: "label",
-                           label: `Edit Team`,
+                           view: "template",
+                           template: "#value#",
                            align: "center",
+                           height: 40,
+                           css: {
+                              "font-weight": 400,
+                              "font-size": "32px",
+                              "font-family": `"Jomhuria", sans-serif`,
+                              color: "white",
+                              background: "transparent",
+                              border: "none",
+                           },
                            id: this.ids.teamFormTitle,
                         },
                         {
-                           view: "button",
-                           value: "X",
+                           view: "icon",
+                           icon: "fa fa-times",
                            align: "right",
                            width: 60,
-                           css: "webix_transparent",
                            click: () => $teamFormPopup.hide(),
                         },
                      ],
@@ -1635,11 +1648,13 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                   {
                      view: "form",
                      id: this.ids.teamForm,
+                     borderless: true,
                      elements: [
                         {
                            view: "text",
                            label: nameField.label ?? nameField.columnName,
                            name: nameField.columnName,
+                           required: true,
                         },
                         {
                            view: "richselect",
@@ -1647,6 +1662,7 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                               strategyField.label ?? strategyField.columnName,
                            name: strategyField.columnName,
                            options: strategyOptions.map(fieldToOption),
+                           required: true,
                         },
                         {
                            view: "switch",
@@ -1657,23 +1673,35 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                         { view: "text", name: "id", hidden: true },
                         { view: "text", name: linkField, hidden: true },
                         {
-                           view: "button",
-                           id: this.ids.teamFormSubmit,
-                           value: "Add",
-                           css: "webix_primary",
-                           click: () => {
-                              const values = $$(this.ids.teamForm).getValues();
-                              const strategy = strategyOptions.find(
-                                 (f) =>
-                                    f.id === values[strategyField.columnName]
-                              );
-                              if (values.id) {
-                                 this.teamEdit(values, strategy);
-                              } else {
-                                 this.teamAddChild(values, strategy);
-                              }
-                              $teamFormPopup.hide();
-                           },
+                           cols: [
+                              {},
+                              {
+                                 view: "template",
+                                 id: this.ids.teamFormSubmit,
+                                 template: "#value#",
+                                 height: 31,
+                                 css: "team-form-button",
+                                 onClick: {
+                                    "team-form-button": () => {
+                                       const values = $$(
+                                          this.ids.teamForm
+                                       ).getValues();
+                                       const strategy = strategyOptions.find(
+                                          (f) =>
+                                             f.id ===
+                                             values[strategyField.columnName]
+                                       );
+                                       if (values.id) {
+                                          this.teamEdit(values, strategy);
+                                       } else {
+                                          this.teamAddChild(values, strategy);
+                                       }
+                                       $teamFormPopup.hide();
+                                    },
+                                 },
+                              },
+                              {},
+                           ],
                         },
                      ],
                   },
@@ -1685,9 +1713,10 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          values[linkField] = values.__parentID;
          delete values.__parentID;
       }
-      $$(this.ids.teamFormTitle).define("label", `${mode} Team`);
-      $$(this.ids.teamFormTitle).refresh();
-      $$(this.ids.teamFormSubmit).setValue(mode);
+      $$(this.ids.teamFormTitle).setValues({
+         value: `${this.label(mode)} Team`,
+      });
+      $$(this.ids.teamFormSubmit).setValues({ value: this.label("Submit") });
       $$(this.ids.teamForm).setValues(values);
       this.teamCanInactivate(values)
          ? $$(this.ids.teamFormInactive).enable()

--- a/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
@@ -99,8 +99,12 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          );
          if (!this._entityChangeListener) {
             // Reload the Chart if our Entity changes
-            this._entityChangeListener = this.entityDC.on("changeCursor", () =>
-               this.refresh()
+            this._entityChangeListener = this.entityDC.on(
+               "changeCursor",
+               () => {
+                  delete this.entitySrategyOptions;
+                  this.refresh();
+               }
             );
          }
       }
@@ -1578,7 +1582,27 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
          const [strategyField] = this.datacollection.datasource.fields(
             (f) => f.id == this.view.settings["teamStrategy"]
          );
-         const strategyOptions = await strategyField.getOptions();
+         if (!this.entityStategyOptions) {
+            const strategyObj = this.AB.objectByID(
+               strategyField.settings.linkObject
+            );
+            const entityLink = strategyObj.connectFields(
+               (f) => f.settings.linkObject === this.entityDC.datasource.id
+            )[0];
+            const cond = {
+               glue: "and",
+               rules: [
+                  {
+                     key: entityLink.columnName,
+                     value: this.entityDC.getCursor().id,
+                     rule: "equals",
+                  },
+               ],
+            };
+            this.entitySrategyOptions = await strategyField.getOptions(cond);
+         }
+         const strategyOptions = this.entitySrategyOptions;
+
          $teamFormPopup = webix.ui({
             view: "popup",
             id: this.ids.teamFormPopup,

--- a/styles/team-widget.css
+++ b/styles/team-widget.css
@@ -260,3 +260,19 @@ org-chart tr.lines .downLine {
 .filter-apply > div > button > span {
    color: #2f27ce !important;
 }
+
+@keyframes skeleton {
+   0% { background-color: #ddd; }
+   50%   { background-color: #eee; }
+   100% { background-color: #ddd}
+}
+
+.team-node-skeleton .content {
+   /* background: grey; */
+   border-radius: 15px !important;
+   height: 100px !important;
+   /* width: 325px; */
+   animation-name: skeleton;
+   animation-duration: 2s;
+   animation-iteration-count: infinite;
+}

--- a/styles/team-widget.css
+++ b/styles/team-widget.css
@@ -214,7 +214,7 @@ org-chart tr.lines .downLine {
 }
 
 .filter-popup {
-   border-radius: 10px;
+   border-radius: 15px;
    background: #fff;
    box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 }
@@ -255,4 +255,8 @@ org-chart tr.lines .downLine {
 
 .team-form-button:disabled {
    background: #AAA;
+}
+
+.filter-apply > div > button > span {
+   color: #2f27ce !important;
 }

--- a/styles/team-widget.css
+++ b/styles/team-widget.css
@@ -239,6 +239,7 @@ org-chart tr.lines .downLine {
 }
 
 .team-form-button {
+   padding: 3px 10px;
    text-align: center;
    font-weight: 400;
    font-size: 17px;
@@ -250,4 +251,8 @@ org-chart tr.lines .downLine {
 
 .team-form-button:hover {
    background: #0e2341;
+}
+
+.team-form-button:disabled {
+   background: #AAA;
 }

--- a/styles/team-widget.css
+++ b/styles/team-widget.css
@@ -178,7 +178,7 @@ org-chart tr.lines .downLine {
    border-radius: 5px;
    cursor: pointer;
    font-size: 8px;
-   color: white;
+   color: white !important;
 }
 
 .team-chart-toolbar {
@@ -236,4 +236,18 @@ org-chart tr.lines .downLine {
 .is-inactive {
    background: grey;
    cursor: default;
+}
+
+.team-form-button {
+   text-align: center;
+   font-weight: 400;
+   font-size: 17px;
+   font-family: "Roboto" sans-serif;
+   color: white;
+   background: #1a3e72;
+   border-radius: 10px;
+}
+
+.team-form-button:hover {
+   background: #0e2341;
 }


### PR DESCRIPTION
https://github.com/digi-serve/planning/issues/581

I wanted to work on this more:
- Improve the skeleton chart (shown while loading data).
- Modify populate on data to the minimum we need.
- ~~Sometimes the chart doesn't load the first team (because the entity is not set yet).~~ https://github.com/digi-serve/ab_platform_web/pull/606
- ~~I'm not sure if the drag employee is creating assignments properly (might be a problem with my local objects)~~ https://github.com/digi-serve/ab_platform_web/pull/606

Most of the changes are just to move some functions to the class so we can reuse them.

## Release Notes
<!-- #release_notes -->
- add a spinner while loading
- allow adding team assignments without refreshing the chart
- reduce requests made to load the content data
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
