### PR TITLE
Add the 'By Query Field' filter option to connected fields with a 1:M relationship type

### DIFF
--- a/AppBuilder/platform/FilterComplex.js
+++ b/AppBuilder/platform/FilterComplex.js
@@ -663,8 +663,7 @@ module.exports = class FilterComplex extends FilterComplexCore {
                .concat(this.uiUserValue(field))
                .concat(this.uiDataCollectionValue(field))
                .concat(this.uiContextValue(field))
-               .concat(this.uiNoneValue())
-               .concat(this.uiQueryFieldValue(field, defaultValue));
+               .concat(this.uiNoneValue());
             break;
          case "date":
          case "datetime":
@@ -693,13 +692,17 @@ module.exports = class FilterComplex extends FilterComplexCore {
       // Add filter options to Custom index
       const LinkType = `${field?.settings?.linkType}:${field?.settings?.linkViaType}`;
       if (
-         field?.settings?.isCustomFK &&
          // 1:M
-         (LinkType == "one:many" ||
-            // 1:1 isSource = true
-            (LinkType == "one:one" && field?.settings?.isSource))
+         LinkType == "one:many" ||
+         // 1:1 isSource = true
+         (LinkType == "one:one" && field?.settings?.isSource)
       ) {
-         result = (result ?? []).concat(this.uiTextValue(field));
+         result = result ?? [];
+
+         if (field?.settings?.isCustomFK)
+            result = result.concat(this.uiTextValue(field));
+
+         result = result.concat(this.uiQueryFieldValue(field, defaultValue));
       } else if (field?.key != "connectObject") {
          result = (result ?? [])
             .concat(this.uiTextValue(field))

--- a/AppBuilder/platform/FilterComplex.js
+++ b/AppBuilder/platform/FilterComplex.js
@@ -610,7 +610,8 @@ module.exports = class FilterComplex extends FilterComplexCore {
                .concat(this.uiUserValue(field))
                .concat(this.uiDataCollectionValue(field))
                .concat(this.uiContextValue(field))
-               .concat(this.uiNoneValue());
+               .concat(this.uiNoneValue())
+               .concat(this.uiQueryFieldValue(field, defaultValue));
             break;
          case "date":
          case "datetime":


### PR DESCRIPTION
## Release Notes
<!-- #release_notes -->
- Add the 'By Query Field' filter option to connected fields with a 1:M relationship type
<!-- /release_notes --> 