### PR TITLE
Make sure Detail components have data to work with on "cursorStale" handlers

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewDetailComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDetailComponent.js
@@ -79,6 +79,12 @@ module.exports = class ABViewDetailComponent extends ABViewContainerComponent {
    }
 
    displayData(rowData = {}) {
+      // make sure we have data to work with.  If null is passed in
+      // then pull current cursor.
+      if (rowData == null) {
+         rowData = this.datacollection.getCursor();
+      }
+
       const views = (this.view.views() || []).sort((a, b) => {
          if (!a?.field?.() || !b?.field?.()) return 0;
 


### PR DESCRIPTION
This is another fix for [ns_app#550](https://github.com/digi-serve/ns_app/issues/550).

In this case, our `ab.datacollection.update`s were triggering a `cursorStale` with `null` as the parameter passed.

Our Detail Components were expecting proper values sent into the display data handler.

## Release Notes
<!-- #release_notes -->
- [fix] make sure Detail components have data to work with on "cursorStale" with null passed in.
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
