### PR TITLE
when drag from employee list don't end existing assignment

### DIFF
--- a/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewOrgChartTeamsComponent.js
@@ -131,18 +131,20 @@ module.exports = class ABViewOrgChartTeamsComponent extends ABViewComponent {
                   contentObj.fieldByID(contentLinkedFieldID).columnName;
                const pendingPromises = [];
                const newDate = new Date();
-               const $contentRecords =
-                  document.getElementsByClassName("team-group-record");
-               for (const $contentRecord of $contentRecords) {
-                  const contentData = JSON.parse($contentRecord.dataset.source);
-                  if (contentData[contentLinkedFieldColumnName] == dataPK) {
-                     contentData[contentDateEndFieldColumnName] = newDate;
-                     pendingPromises.push(
-                        contentModel.update(contentData.id, contentData)
-                     );
-                     draggedNodes.push($contentRecord);
-                  }
-               }
+               // Employee can have multiple assignments, so don't close
+               // existing
+               // const $contentRecords =
+               // document.getElementsByClassName("team-group-record");
+               // for (const $contentRecord of $contentRecords) {
+               //    const contentData = JSON.parse($contentRecord.dataset.source);
+               //    if (contentData[contentLinkedFieldColumnName] == dataPK) {
+               //       contentData[contentDateEndFieldColumnName] = newDate;
+               //       pendingPromises.push(
+               //          contentModel.update(contentData.id, contentData)
+               //       );
+               //       draggedNodes.push($contentRecord);
+               //    }
+               // }
                updatedData = {};
                updatedData[contentDateStartFieldColumnName] = newDate;
                updatedData[contentLinkedFieldColumnName] =


### PR DESCRIPTION
https://github.com/digi-serve/global-hr-update/issues/202
## Release Notes
<!-- #release_notes -->
- fix: adding a person to a 2nd team removes first assignment
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
