### PR TITLE
Add support for view plugins

### DIFF
--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -37,6 +37,7 @@ import Tenant from "../resources/Tenant.js";
 // Tenant: manages the Tenant information of the current instance
 
 import UISettings from "./uiSettings/config.js";
+import ABViewComponent from "./platform/views/viewComponent/ABViewComponent.js";
 // UISettings: detailed settings for our common UI elements
 
 class ABValidator {
@@ -113,6 +114,7 @@ class ABFactory extends ABFactoryCore {
       this.Class.FilterComplex = FilterComplex;
       this.Class.ABViewManager = ABViewManager;
       this.Class.SortPopup = SortPopup;
+      this.Class.ABViewComponent = ABViewComponent;
 
       // Temp placeholders until Resources are implemented:
       this.Analytics = {

--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -132,6 +132,8 @@ class ABFactory extends ABFactoryCore {
          }
       };
 
+      this.performance = performance;
+
       this.UISettings = UISettings;
 
       this.Validation = {

--- a/AppBuilder/platform/views/viewComponent/ABViewDataSelectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDataSelectComponent.js
@@ -16,7 +16,7 @@ export default class ABViewDataSelectComponent extends ABViewComponent {
    ui() {
       const _ui = super.ui([
          {
-            view: "richselect",
+            view: "combo",
             id: this.ids.select,
             on: {
                onChange: (n, o) => {
@@ -43,7 +43,8 @@ export default class ABViewDataSelectComponent extends ABViewComponent {
       )?.columnName;
       const options = this.dc
          .getData()
-         .map((o) => ({ id: o.id, value: o[labelField] }));
+         .map((o) => ({ id: o.id, value: o[labelField] }))
+         .sort((a, b) => (a.value > b.value ? 1 : -1));
       $$(this.ids.select).define("options", options);
       $$(this.ids.select).refresh();
       $$(this.ids.select).setValue(this.dc.getCursor().id);

--- a/AppBuilder/platform/views/viewComponent/ABViewDataSelectComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewDataSelectComponent.js
@@ -30,27 +30,25 @@ export default class ABViewDataSelectComponent extends ABViewComponent {
       return _ui;
    }
 
-   async init(AB) {
-      await super.init(AB);
-      this.dc = AB.datacollectionByID(this.settings.dataviewID);
-   }
-
    async onShow() {
-      if (!this.dc) return;
-      await this.dc.waitForDataCollectionToInitialize(this.dc);
+      super.onShow();
+      const dc = this.datacollection;
+      if (!dc) return;
+      await dc.waitReady();
       const labelField = this.AB.definitionByID(
          this.settings.labelField
       )?.columnName;
-      const options = this.dc
+      const options = dc
          .getData()
          .map((o) => ({ id: o.id, value: o[labelField] }))
          .sort((a, b) => (a.value > b.value ? 1 : -1));
-      $$(this.ids.select).define("options", options);
-      $$(this.ids.select).refresh();
-      $$(this.ids.select).setValue(this.dc.getCursor().id);
+      const $select = $$(this.ids.select);
+      $select.define("options", options);
+      $select.refresh();
+      $select.setValue(dc.getCursor().id);
    }
 
    cursorChange(n) {
-      this.dc.setCursor(n);
+      this.datacollection.setCursor(n);
    }
 }

--- a/ui/portal_work.js
+++ b/ui/portal_work.js
@@ -290,7 +290,7 @@ class PortalWork extends ClassUI {
                a.isWebApp &&
                a.isAccessibleForRoles(this.AB.Account.rolesAll() ?? [])
          ) || []
-      ).concat(this.AB.plugins() || []);
+      ).concat(this.AB.plugins().filter((p) => p.pages) || []);
 
       // Build out our Navigation Side Bar Menu with our available
       // ABApplications
@@ -578,7 +578,7 @@ class PortalWork extends ClassUI {
       const allPlaceholders = [];
 
       for (let i = 0; i < allApplications.length; i++) {
-         const pages = allApplications[i].pages() || [];
+         const pages = allApplications[i].pages?.() || [];
 
          for (let j = 0; j < pages.length; j++) {
             if (pages[j].getUserAccess?.() === 0) continue;
@@ -641,7 +641,7 @@ class PortalWork extends ClassUI {
       // Step 5: initialize the remaining Pages
       //
       for (let i = 0; i < allApplications.length; i++) {
-         const pages = allApplications[i].pages() || [];
+         const pages = allApplications[i].pages?.() || [];
 
          for (let j = 0; j < pages.length; j++) {
             if (pages[j].getUserAccess?.() === 0) continue;


### PR DESCRIPTION
As we're moving closer to HR Teams release, I want to move away from needing to maintain different branches and building manually. I packaged the HR Teams Complex Widget as a plugin, in the style of ABDesigner. But this requires modification to ABDesigner, platform_web and core to load the relevant classes.

See the plugin code here: https://github.com/digi-serve/plugin_HRTeams

The main goal is code separation. I still think we need to work on a more accessible plugin system, that simplifies adding custom features to the platform.

## Release Notes
<!-- #release_notes -->
- add support for plugins without pages
- add ABViewComponent class to ABFactory so a plugin can extend from it
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
