### PR TITLE
CSV Packing of Data (web platform)

### DIFF
--- a/AppBuilder/ABFactory.js
+++ b/AppBuilder/ABFactory.js
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 import performance from "../utils/performance";
 import FilterComplex from "./platform/FilterComplex";
 import SortPopup from "./platform/views/ABViewGridPopupSortFields";
+import Papa from "papaparse";
 
 //
 // Our Common Resources
@@ -1057,6 +1058,17 @@ class ABFactory extends ABFactoryCore {
    async cssLoadAll(urls) {
       urls = urls.filter((u) => u);
       await Promise.all(urls.map((url) => this.cssLoad(url)));
+   }
+
+   csvToJson(csvData) {
+      return Papa.parse(csvData, {
+         header: true,
+         skipEmptyLines: true,
+      });
+   }
+
+   jsonToCsv(jsonData) {
+      return Papa.unparse(jsonData);
    }
 }
 

--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -107,6 +107,17 @@ module.exports = class ABModel extends ABModelCore {
                this.normalizeData(data);
             }
          } else {
+            if (this.isCsvPacked(data)) {
+               let lengthPacked = JSON.stringify(data).length;
+               data = this.csvUnpack(data);
+               let lengthUnpacked = JSON.stringify(data).length;
+               console.log(
+                  `CSV Pack: ${lengthUnpacked} -> ${lengthPacked} (${(
+                     (lengthPacked / lengthUnpacked) *
+                     100
+                  ).toFixed(2)}%)`
+               );
+            }
             // on a findAll we normalize data.data
             this.normalizeData(data.data);
          }

--- a/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
+++ b/AppBuilder/platform/views/viewComponent/ABViewGridComponent.js
@@ -1495,7 +1495,7 @@ export default class ABViewGridComponent extends ABViewComponent {
             //       }
             //    });
          } else validator.updateGrid(editor.row, $DataTable);
-      } else $DataTable.clearSelection();
+      } else $DataTable?.clearSelection();
 
       return false;
 
@@ -1733,7 +1733,8 @@ export default class ABViewGridComponent extends ABViewComponent {
          columnHeaders = ab.cloneDeep(this.settings.columnConfig);
 
       // if that is empty for some reason, rebuild from our CurrentObject
-      if (columnHeaders.length === 0) columnHeaders = objColumnHeaders;
+      if (!columnHeaders || columnHeaders.length === 0)
+         columnHeaders = objColumnHeaders;
 
       // sanity check:
       // columnHeaders can't contain a column that doesn't exist in objColumHeaders:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "image-size": "^1.1.1",
     "jszip-utils": "^0.1.0",
     "nanoid": "^3.3.4",
+    "papaparse": "^5.5.2",
     "pdfjs-dist": "^4.2.67",
     "sails.io.js": "^1.2.1",
     "semver": "^7.7.1",

--- a/resources/NetworkRest.js
+++ b/resources/NetworkRest.js
@@ -329,10 +329,14 @@ class NetworkRest extends EventEmitter {
                            null
                         );
                      }
-                     return reject(packet.message ?? packet.data);
+                     let error = new Error(packet.message ?? packet.data);
+                     error.response = packet;
+                     error.text = packet.message;
+                     error.url = `${params.method} ${params.url}`;
+                     return reject(error);
                   } else {
                      // unknown/unexpected error:
-                     var error = new Error(
+                     let error = new Error(
                         `${err.status} ${err.statusText || err.message}: ${
                            params.method
                         } ${params.url}`

--- a/resources/NetworkRest.js
+++ b/resources/NetworkRest.js
@@ -329,7 +329,7 @@ class NetworkRest extends EventEmitter {
                            null
                         );
                      }
-                     return reject(packet.data);
+                     return reject(packet.message ?? packet.data);
                   } else {
                      // unknown/unexpected error:
                      var error = new Error(

--- a/webix_custom_components/formioBuilder.js
+++ b/webix_custom_components/formioBuilder.js
@@ -85,7 +85,8 @@ export default class ABCustomFormBuilderBuilder extends ABLazyCustomComponent {
          },
          // set up a function that can be called to request the form schema
          getFormData: function () {
-            return this.builder.schema;
+            if (this.builder.schema) return this.builder.schema;
+            return this.builder.instance.schema;
          },
          // Pass functions into the Webix component to be use in $init
          label: this.label,


### PR DESCRIPTION
Initial Implementation of CSV Packing of our Data.

Currently we have been using json as our exchange format between our client and server.  For for larger data sets, the json format repeats a lot of data for the field names. ex:
```
[ 
	{
		"firstName": "Neo",
		"lastName" : "Andersong",
	},
	{
		"firstName": "Morpheous",
		"lastName" : "",
	},
	{
		"firstName": "Trinity",
		"lastName" : ""
	}
]
```

using csv, we can reduce the repeated column information:
```
firstName,lastName
"Neo","Anderson"
"Morpheous",""
"Trinity",""
```

The larger the dataset, the greater the savings. 

The previous data exchange format was
```
{
    data: [{obj1}, {obj2}, ... {objN}],
    total_bytes:xx,
}
```
This change now encodes our data in the following format:
```
{
  csv_packed:{
    data: "csv of primary data",
    relations: {
      {connectionFieldID}: "csv of relation data", // each entry has entry._csvID, that is the lookup
      {connectionFieldID}: "csv of relation data",
      ...
  }
  total_bytes:xx,
}
```

This will happen for any direct request to the appbuilder.model-get, model-patch, model-update services as well as any broadcast that happens as a result of one of those operations.

This PR is part of a series of updates: [class_core](https://github.com/digi-serve/appbuilder_class_core/pull/290), [platform_web](https://github.com/digi-serve/ab_platform_web/pull/646), [platform_service](https://github.com/digi-serve/appbuilder_platform_service/pull/168), [appbuilder service](https://github.com/digi-serve/ab_service_appbuilder/pull/119)

## Release Notes
<!-- #release_notes -->
- [wip] implementing CSV Packing of data on Web Platform
<!-- /release_notes --> 

## Test Status
Actually, I've been using the existing Kitchensink app as our tests. This should be working as expected if that keeps working out all the variations of data being exchanged between the client and server.
