### PR TITLE
Improve Performance by returning strings

### DIFF
--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -98,6 +98,16 @@ module.exports = class ABModel extends ABModelCore {
             return;
          }
 
+         // String Results
+         if (typeof data === "string") {
+            // if we have a string, then we are expecting a json object
+            try {
+               data = JSON.parse(data);
+            } catch (e) {
+               // if we can't parse the string, then just return it as is.
+            }
+         }
+
          // let jobID = this.AB.jobID();
          // console.log(`${jobID} : normalization begin`);
          // let timeFrom = performance.now();


### PR DESCRIPTION
I was noticing some Performance lags in our responses when our `api_sails` service handlers were having to `JSON.parse()` the responses before sending them off.

This patch will allow the service handlers to simply send back the strings un parsed.

However, this patch needs to [this PR]() in order to work.



## Release Notes
<!-- #release_notes -->
- [wip] ensure model responses are json
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
