### PR TITLE
Fix RANGE ERROR when calculating the CSV Pack changes

### DIFF
--- a/AppBuilder/platform/ABModel.js
+++ b/AppBuilder/platform/ABModel.js
@@ -110,7 +110,25 @@ module.exports = class ABModel extends ABModelCore {
             if (this.isCsvPacked(data)) {
                let lengthPacked = JSON.stringify(data).length;
                data = this.csvUnpack(data);
-               let lengthUnpacked = JSON.stringify(data).length;
+
+               // JOHNNY: getting "RangeError: Invalid string length"
+               // when data.data is too large. So we are just going
+               // to .stringify() the rows individually and count the
+               // length of each one.
+
+               let lengthUnpacked = 0;
+               for (var d = 0; d < data.data.length; d++) {
+                  lengthUnpacked += JSON.stringify(data.data[d]).length;
+               }
+
+               Object.keys(data)
+                  .filter((k) => k != "data")
+                  .map((k) => {
+                     lengthUnpacked += `${k}:${data[k]},`.length;
+                  });
+
+               lengthUnpacked += 5; // for the brackets
+
                console.log(
                   `CSV Pack: ${lengthUnpacked} -> ${lengthPacked} (${(
                      (lengthPacked / lengthUnpacked) *


### PR DESCRIPTION
If the incoming data was really large, our JSON.stringify() approach can result in a RAGE ERROR when running out of memory.

We fix this by only JSON.stringify() each individual row, and then sum the lengths together.

## Release Notes
<!-- #release_notes -->
- [fix] Range Error when incoming data is too large: calculate unpacked length more efficiently
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
