### PR TITLE
Add page routing by query params

### DIFF
--- a/ui/portal_work.js
+++ b/ui/portal_work.js
@@ -503,16 +503,17 @@ class PortalWork extends ClassUI {
       // Ref: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
       const queryParams = new URLSearchParams(window.location.search);
       if (queryParams.has("app") && queryParams.has("page")) {
-         const appID = queryParams.get("app");
+         const appParam = queryParams.get("app");
          // Check its a real appID to address: https://github.com/digi-serve/ab_platform_web/security/code-scanning/630
-         if (!this.AB.applicationByID(appID)) {
-            console.error(`Trying to Navigate to unknown app ${appID}`);
+         const app = this.AB.applicationByID(appParam);
+         if (!app) {
+            console.error(`Trying to Navigate to unknown app ${appParam}`);
          } else {
             this.AppState = {
-               lastSelectedApp: appID,
+               lastSelectedApp: app.id,
                lastPages: {},
             };
-            this.AppState.lastPages[appID] = queryParams.get("page");
+            this.AppState.lastPages[app.id] = queryParams.get("page");
          }
       }
 

--- a/ui/portal_work.js
+++ b/ui/portal_work.js
@@ -504,11 +504,16 @@ class PortalWork extends ClassUI {
       const queryParams = new URLSearchParams(window.location.search);
       if (queryParams.has("app") && queryParams.has("page")) {
          const appID = queryParams.get("app");
-         this.AppState = {
-            lastSelectedApp: appID,
-            lastPages: {},
-         };
-         this.AppState.lastPages[appID] = queryParams.get("page");
+         // Check its a real appID to address: https://github.com/digi-serve/ab_platform_web/security/code-scanning/630
+         if (!this.AB.applicationByID(appID)) {
+            console.error(`Trying to Navigate to unknown app ${appID}`);
+         } else {
+            this.AppState = {
+               lastSelectedApp: appID,
+               lastPages: {},
+            };
+            this.AppState.lastPages[appID] = queryParams.get("page");
+         }
       }
 
       // 1.2 Load the last app / page from storage

--- a/ui/portal_work.js
+++ b/ui/portal_work.js
@@ -492,8 +492,30 @@ class PortalWork extends ClassUI {
       //
       // Step 1: prepare the AppState so we can determine which options
       // should be pre selected.
-      //
-      const AppState = (await this.AB.Storage.get(this.storageKey)) ?? {
+
+      /**
+       * @typedef {Object} AppState
+       * @property {string} lastSelectedApp ABApplication.id of the last App selected,
+       * @property {Object} lastPages a lookup of all the last selected Pages for each Application {hash}  { ABApplication.id : ABPage.id }
+       */
+
+      // 1.1 Check for App & Page secified on the route (query params /?app=...&page=...)
+      // Ref: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
+      const queryParams = new URLSearchParams(window.location.search);
+      if (queryParams.has("app") && queryParams.has("page")) {
+         const appID = queryParams.get("app");
+         this.AppState = {
+            lastSelectedApp: appID,
+            lastPages: {},
+         };
+         this.AppState.lastPages[appID] = queryParams.get("page");
+      }
+
+      // 1.2 Load the last app / page from storage
+      this.AppState =
+         this.AppState ?? (await this.AB.Storage.get(this.storageKey));
+      // 1.3 Create a new AppState
+      this.AppState = this.AppState ?? {
          lastSelectedApp: null,
          // {string}  the ABApplication.id of the last App selected
 
@@ -501,8 +523,6 @@ class PortalWork extends ClassUI {
          // {hash}  { ABApplication.id : ABPage.id }
          // a lookup of all the last selected Pages for each Application
       };
-
-      this.AppState = AppState;
 
       // set default selected App if not already set
       // just choose the 1st App in the list (must have pages that we have


### PR DESCRIPTION
Adds support for linking pages:
`http://admin.myappbuilder.com?app=[appID]&page=[pageID]`

## Release Notes
<!-- #release_notes -->
- Allow linking to a page with query params
<!-- /release_notes --> 

## Test Status
<!-- Link to a new test, or explain why it's not needed -->
Tested locally